### PR TITLE
Use linkme to register fixture patchers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "fixture_macros",
  "itertools 0.13.0",
  "lazy_static",
+ "linkme",
  "local-ip-address",
  "log 0.4.22",
  "num-derive",
@@ -1408,7 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1429,6 +1430,26 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3597,7 +3618,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ fixture_macros = { path = "fixture_macros" }
 rand = { version = "0.8", features = ["small_rng"] }
 wled-json-api-library = "0.1.7"
 reqwest = "0.12.9"
+linkme = "0.3.33"

--- a/src/fixture/mod.rs
+++ b/src/fixture/mod.rs
@@ -42,6 +42,6 @@ pub mod prelude {
     pub use crate::master::MasterControls;
     pub use crate::osc::prelude::*;
     pub use anyhow::bail;
-    pub use fixture_macros::{Control, EmitState};
+    pub use fixture_macros::{Control, EmitState, PatchAnimatedFixture, PatchFixture};
     pub use number::{BipolarFloat, Phase, UnipolarFloat};
 }

--- a/src/fixture/profile/aquarius.rs
+++ b/src/fixture/profile/aquarius.rs
@@ -1,7 +1,8 @@
 //! Intuitive control profile for the American DJ Aquarius 250.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 2]
 pub struct Aquarius {
     #[channel_control]
     lamp_on: ChannelLevelBool<BoolChannel>,
@@ -19,13 +20,6 @@ impl Default for Aquarius {
                 .with_mirroring(true)
                 .with_channel_knob(0),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Aquarius {
-    const NAME: FixtureType = FixtureType("Aquarius");
-    fn channel_count(&self) -> usize {
-        2
     }
 }
 

--- a/src/fixture/profile/astera.rs
+++ b/src/fixture/profile/astera.rs
@@ -3,7 +3,8 @@ use super::color::Model::Rgb;
 
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 20]
 pub struct Astera {
     #[channel_control]
     #[animate]
@@ -75,13 +76,6 @@ impl Default for Astera {
             sat4: Unipolar::new("Sat4", ()),
             val4: Unipolar::new("Val4", ()),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Astera {
-    const NAME: FixtureType = FixtureType("Astera");
-    fn channel_count(&self) -> usize {
-        20
     }
 }
 

--- a/src/fixture/profile/astroscan.rs
+++ b/src/fixture/profile/astroscan.rs
@@ -1,7 +1,8 @@
 //! Clay Paky Astroscan - drunken sailor extraordinaire
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 9]
 pub struct Astroscan {
     lamp_on: BoolChannel,
     #[channel_control]
@@ -63,13 +64,6 @@ impl Default for Astroscan {
                 .with_detent()
                 .with_mirroring(false),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Astroscan {
-    const NAME: FixtureType = FixtureType("Astroscan");
-    fn channel_count(&self) -> usize {
-        9
     }
 }
 

--- a/src/fixture/profile/color.rs
+++ b/src/fixture/profile/color.rs
@@ -58,6 +58,8 @@ impl PatchAnimatedFixture for Color {
     }
 }
 
+crate::register!(Color);
+
 impl Color {
     pub fn render_without_animations(&self, dmx_buf: &mut [u8]) {
         self.model.render(

--- a/src/fixture/profile/colordynamic.rs
+++ b/src/fixture/profile/colordynamic.rs
@@ -3,7 +3,8 @@
 
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 4]
 pub struct Colordynamic {
     #[channel_control]
     shutter: ChannelLevelBool<FullShutterStrobe>,
@@ -35,13 +36,6 @@ impl Default for Colordynamic {
                 .with_detent()
                 .with_channel_knob(2),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Colordynamic {
-    const NAME: FixtureType = FixtureType("Colordynamic");
-    fn channel_count(&self) -> usize {
-        4
     }
 }
 

--- a/src/fixture/profile/comet.rs
+++ b/src/fixture/profile/comet.rs
@@ -37,6 +37,8 @@ impl PatchFixture for Comet {
     }
 }
 
+crate::register!(Comet);
+
 impl NonAnimatedFixture for Comet {
     fn render(&self, _group_controls: &FixtureGroupControls, dmx_buf: &mut [u8]) {
         if !self.shutter_open.val() {

--- a/src/fixture/profile/cosmic_burst.rs
+++ b/src/fixture/profile/cosmic_burst.rs
@@ -1,7 +1,8 @@
 //! Control profile for the Cosmic Burst white laser moonflower.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 6]
 pub struct CosmicBurst {
     #[channel_control]
     #[animate]
@@ -21,13 +22,6 @@ impl Default for CosmicBurst {
                 .with_mirroring(true)
                 .with_channel_knob(0),
         }
-    }
-}
-
-impl PatchAnimatedFixture for CosmicBurst {
-    const NAME: FixtureType = FixtureType("CosmicBurst");
-    fn channel_count(&self) -> usize {
-        6
     }
 }
 

--- a/src/fixture/profile/dimmer.rs
+++ b/src/fixture/profile/dimmer.rs
@@ -1,7 +1,8 @@
 //! Control profile for a dimmer.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 1]
 pub struct Dimmer {
     #[channel_control]
     #[animate]
@@ -13,13 +14,6 @@ impl Default for Dimmer {
         Self {
             level: Unipolar::full_channel("Level", 0).with_channel_level(),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Dimmer {
-    const NAME: FixtureType = FixtureType("Dimmer");
-    fn channel_count(&self) -> usize {
-        1
     }
 }
 

--- a/src/fixture/profile/faderboard.rs
+++ b/src/fixture/profile/faderboard.rs
@@ -18,6 +18,8 @@ impl PatchFixture for Faderboard {
     }
 }
 
+crate::register!(Faderboard);
+
 const DEFAULT_CHANNEL_COUNT: usize = 16;
 
 impl Default for Faderboard {

--- a/src/fixture/profile/freedom_fries.rs
+++ b/src/fixture/profile/freedom_fries.rs
@@ -6,7 +6,8 @@ use super::color::Color;
 
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 8]
 pub struct FreedomFries {
     #[channel_control]
     #[animate]
@@ -30,13 +31,6 @@ impl Default for FreedomFries {
 
             program: ProgramControl::default(),
         }
-    }
-}
-
-impl PatchAnimatedFixture for FreedomFries {
-    const NAME: FixtureType = FixtureType("FreedomFries");
-    fn channel_count(&self) -> usize {
-        8
     }
 }
 

--- a/src/fixture/profile/freq_strobe.rs
+++ b/src/fixture/profile/freq_strobe.rs
@@ -8,7 +8,8 @@ use crate::fixture::prelude::*;
 
 const CELL_COUNT: usize = 16;
 
-#[derive(EmitState, Control)]
+#[derive(EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 18]
 pub struct FreqStrobe {
     #[channel_control]
     #[animate]
@@ -37,13 +38,6 @@ impl Default for FreqStrobe {
             reverse: Bool::new_off("Reverse", ()),
             flasher,
         }
-    }
-}
-
-impl PatchAnimatedFixture for FreqStrobe {
-    const NAME: FixtureType = FixtureType("FreqStrobe");
-    fn channel_count(&self) -> usize {
-        18
     }
 }
 

--- a/src/fixture/profile/fusion_roll.rs
+++ b/src/fixture/profile/fusion_roll.rs
@@ -1,6 +1,7 @@
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 11]
 pub struct FusionRoll {
     #[channel_control]
     #[animate]
@@ -59,13 +60,6 @@ impl Default for FusionRoll {
                 Strobe::channel("LaserStrobe", 6, 16, 131, 8),
             ),
         }
-    }
-}
-
-impl PatchAnimatedFixture for FusionRoll {
-    const NAME: FixtureType = FixtureType("FusionRoll");
-    fn channel_count(&self) -> usize {
-        11
     }
 }
 

--- a/src/fixture/profile/h2o.rs
+++ b/src/fixture/profile/h2o.rs
@@ -1,7 +1,8 @@
 //! Intuitive control profile for the American DJ H2O DMX Pro.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 3]
 pub struct H2O {
     #[channel_control]
     #[animate]
@@ -47,13 +48,6 @@ impl Default for H2O {
                 .with_detent()
                 .with_channel_knob(1),
         }
-    }
-}
-
-impl PatchAnimatedFixture for H2O {
-    const NAME: FixtureType = FixtureType("H2O");
-    fn channel_count(&self) -> usize {
-        3
     }
 }
 

--- a/src/fixture/profile/hypnotic.rs
+++ b/src/fixture/profile/hypnotic.rs
@@ -1,7 +1,8 @@
 //! Intuitive control profile for the American DJ Aquarius 250.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 2]
 pub struct Hypnotic {
     red_laser_on: Bool<()>,
     green_laser_on: Bool<()>,
@@ -22,13 +23,6 @@ impl Default for Hypnotic {
                 .with_mirroring(true)
                 .with_channel_knob(0),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Hypnotic {
-    const NAME: FixtureType = FixtureType("Hypnotic");
-    fn channel_count(&self) -> usize {
-        2
     }
 }
 

--- a/src/fixture/profile/leko.rs
+++ b/src/fixture/profile/leko.rs
@@ -59,6 +59,8 @@ impl PatchAnimatedFixture for Leko {
     }
 }
 
+crate::register!(Leko);
+
 impl AnimatedFixture for Leko {
     type Target = AnimationTarget;
 

--- a/src/fixture/profile/lumasphere.rs
+++ b/src/fixture/profile/lumasphere.rs
@@ -28,7 +28,8 @@ const MAX_ROTATION_SPEED: u8 = 100;
 /// the two channels after the lumasphere's built-in controller:
 /// 8: lamp 1 dimmer
 /// 9: lamp 2 dimmer
-#[derive(Debug)]
+#[derive(Debug, PatchFixture)]
+#[channel_count = 9]
 pub struct Lumasphere {
     controls: GroupControlMap<ControlMessage>,
     lamp_1_intensity: UnipolarFloat,
@@ -39,13 +40,6 @@ pub struct Lumasphere {
     color_start: bool,
     strobe_1: Strobe,
     strobe_2: Strobe,
-}
-
-impl PatchFixture for Lumasphere {
-    const NAME: FixtureType = FixtureType("Lumasphere");
-    fn channel_count(&self) -> usize {
-        9
-    }
 }
 
 impl Default for Lumasphere {

--- a/src/fixture/profile/radiance.rs
+++ b/src/fixture/profile/radiance.rs
@@ -42,6 +42,8 @@ impl PatchAnimatedFixture for Radiance {
     }
 }
 
+crate::register!(Radiance);
+
 impl AnimatedFixture for Radiance {
     type Target = AnimationTarget;
 

--- a/src/fixture/profile/rotosphere_q3.rs
+++ b/src/fixture/profile/rotosphere_q3.rs
@@ -3,7 +3,8 @@ use super::color::Model::Rgbw;
 
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 9]
 pub struct RotosphereQ3 {
     #[channel_control]
     #[animate]
@@ -32,13 +33,6 @@ impl Default for RotosphereQ3 {
                 .with_mirroring(true)
                 .with_channel_knob(2),
         }
-    }
-}
-
-impl PatchAnimatedFixture for RotosphereQ3 {
-    const NAME: FixtureType = FixtureType("RotosphereQ3");
-    fn channel_count(&self) -> usize {
-        9
     }
 }
 

--- a/src/fixture/profile/rug_doctor.rs
+++ b/src/fixture/profile/rug_doctor.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use wled_json_api_library::structures::state::{Seg, State};
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 0]
 pub struct RugDoctor {
     #[channel_control]
     #[animate] // FIXME animations aren't actually used, need to fix channel patching
@@ -29,13 +30,6 @@ impl Default for RugDoctor {
             size: Unipolar::new("Size", ()).with_channel_knob(1),
             preset: IndexedSelect::new("Preset", 6, false, ()),
         }
-    }
-}
-
-impl PatchAnimatedFixture for RugDoctor {
-    const NAME: FixtureType = FixtureType("RugDoctor");
-    fn channel_count(&self) -> usize {
-        0
     }
 }
 

--- a/src/fixture/profile/rush_wizard.rs
+++ b/src/fixture/profile/rush_wizard.rs
@@ -2,7 +2,8 @@
 
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 10]
 pub struct RushWizard {
     #[channel_control]
     #[animate]
@@ -70,13 +71,6 @@ impl Default for RushWizard {
             .with_mirroring(true)
             .with_channel_knob(2),
         }
-    }
-}
-
-impl PatchAnimatedFixture for RushWizard {
-    const NAME: FixtureType = FixtureType("RushWizard");
-    fn channel_count(&self) -> usize {
-        10
     }
 }
 

--- a/src/fixture/profile/solar_system.rs
+++ b/src/fixture/profile/solar_system.rs
@@ -1,7 +1,8 @@
 //! Optikinetics Solar System - the grand champion gobo rotator
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 7]
 pub struct SolarSystem {
     #[channel_control]
     shutter_open: ChannelLevelBool<Bool<()>>,
@@ -37,12 +38,6 @@ impl Default for SolarSystem {
     }
 }
 
-impl PatchAnimatedFixture for SolarSystem {
-    const NAME: FixtureType = FixtureType("SolarSystem");
-    fn channel_count(&self) -> usize {
-        7
-    }
-}
 impl ControllableFixture for SolarSystem {}
 
 impl AnimatedFixture for SolarSystem {

--- a/src/fixture/profile/starlight.rs
+++ b/src/fixture/profile/starlight.rs
@@ -1,7 +1,8 @@
 //! Control profile for the "house light" Starlight white laser moonflower.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 4]
 pub struct Starlight {
     #[channel_control]
     #[animate]
@@ -21,13 +22,6 @@ impl Default for Starlight {
                 .with_mirroring(true)
                 .with_channel_knob(0),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Starlight {
-    const NAME: FixtureType = FixtureType("Starlight");
-    fn channel_count(&self) -> usize {
-        4
     }
 }
 

--- a/src/fixture/profile/uv_led_brick.rs
+++ b/src/fixture/profile/uv_led_brick.rs
@@ -1,7 +1,8 @@
 //! Control profile for a uv_led_brick.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 7]
 pub struct UvLedBrick {
     #[channel_control]
     #[animate]
@@ -13,13 +14,6 @@ impl Default for UvLedBrick {
         Self {
             level: Unipolar::full_channel("Level", 0).with_channel_level(),
         }
-    }
-}
-
-impl PatchAnimatedFixture for UvLedBrick {
-    const NAME: FixtureType = FixtureType("UvLedBrick");
-    fn channel_count(&self) -> usize {
-        7
     }
 }
 

--- a/src/fixture/profile/venus.rs
+++ b/src/fixture/profile/venus.rs
@@ -23,7 +23,8 @@ use crate::fixture::prelude::*;
 /// 6 - Motor 4 Dir
 /// 7 - Motor 4 Speed
 /// 8 - Lamp Control
-#[derive(Debug)]
+#[derive(Debug, PatchFixture)]
+#[channel_count = 8]
 pub struct Venus {
     controls: GroupControlMap<ControlMessage>,
     base_rotation: RampingParameter<BipolarFloat>,
@@ -31,13 +32,6 @@ pub struct Venus {
     head_rotation: RampingParameter<BipolarFloat>,
     color_rotation: RampingParameter<BipolarFloat>,
     lamp_on: bool,
-}
-
-impl PatchFixture for Venus {
-    const NAME: FixtureType = FixtureType("Venus");
-    fn channel_count(&self) -> usize {
-        8
-    }
 }
 
 impl Default for Venus {

--- a/src/fixture/profile/wizard_extreme.rs
+++ b/src/fixture/profile/wizard_extreme.rs
@@ -1,7 +1,8 @@
 //! Martin Wizard Extreme - the one that Goes Slow
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 11]
 pub struct WizardExtreme {
     #[channel_control]
     #[animate]
@@ -62,13 +63,6 @@ impl Default for WizardExtreme {
                 .with_mirroring(true)
                 .with_channel_knob(2),
         }
-    }
-}
-
-impl PatchAnimatedFixture for WizardExtreme {
-    const NAME: FixtureType = FixtureType("WizardExtreme");
-    fn channel_count(&self) -> usize {
-        11
     }
 }
 

--- a/src/fixture/profile/wizlet.rs
+++ b/src/fixture/profile/wizlet.rs
@@ -1,7 +1,8 @@
 //! Control profile for the American DJ (Eliminator) Vortex, aka the Wizlet.
 use crate::fixture::prelude::*;
 
-#[derive(Debug, EmitState, Control)]
+#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[channel_count = 12]
 pub struct Wizlet {
     #[channel_control]
     #[animate]
@@ -62,13 +63,6 @@ impl Default for Wizlet {
             strobe: Strobe::channel("Strobe", 4, 64, 95, 32),
             dimmer: Unipolar::full_channel("Dimmer", 5).with_channel_level(),
         }
-    }
-}
-
-impl PatchAnimatedFixture for Wizlet {
-    const NAME: FixtureType = FixtureType("Wizlet");
-    fn channel_count(&self) -> usize {
-        12
     }
 }
 

--- a/src/show.rs
+++ b/src/show.rs
@@ -94,7 +94,7 @@ const UPDATE_INTERVAL: Duration = Duration::from_millis(20);
 impl Show {
     pub fn new(cfg: Config, clocks: Clocks) -> Result<Self> {
         let mut channels = Channels::new();
-        let mut patch = Patch::default();
+        let mut patch = Patch::new();
 
         let controller = Controller::from_config(&cfg)?;
 


### PR DESCRIPTION
- Replaces the explicit collection of fixture patchers with a global registry using the `linkme` crate. This allows fixture types to register themselves with the patch without having to collect them in a centralized location, effectively making the plug-ins.
- Create derive macros for the two Patch traits, and register fixtures in that derive.
