### PR TITLE
Introduce RenderMode index to allow different backends.

### DIFF
--- a/fixture_macros/src/lib.rs
+++ b/fixture_macros/src/lib.rs
@@ -18,7 +18,7 @@ pub fn derive_patch_animated_fixture(input: TokenStream) -> TokenStream {
     quote! {
         impl crate::fixture::patch::PatchAnimatedFixture for #ident {
             const NAME: FixtureType = FixtureType(#name);
-            fn channel_count(&self) -> usize {
+            fn channel_count(&self, _render_mode: Option<crate::fixture::RenderMode>) -> usize {
                 #channel_count
             }
         }
@@ -43,7 +43,7 @@ pub fn derive_patch_fixture(input: TokenStream) -> TokenStream {
     quote! {
         impl crate::fixture::patch::PatchFixture for #ident {
             const NAME: FixtureType = FixtureType(#name);
-            fn channel_count(&self) -> usize {
+            fn channel_count(&self, _render_mode: Option<crate::fixture::RenderMode>) -> usize {
                 #channel_count
             }
         }

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -11,7 +11,7 @@ use number::{Phase, UnipolarFloat};
 use serde::{Deserialize, Serialize};
 
 use super::animation_target::ControllableTargetedAnimation;
-use super::fixture::{Fixture, FixtureType};
+use super::fixture::{Fixture, FixtureType, RenderMode};
 use super::prelude::ChannelStateEmitter;
 use crate::channel::ChannelControlMessage;
 use crate::dmx::DmxBuffer;
@@ -132,6 +132,7 @@ impl FixtureGroup {
                 &FixtureGroupControls {
                     master_controls,
                     mirror: cfg.mirror,
+                    render_mode: cfg.render_mode,
                 },
                 dmx_buf,
             );
@@ -158,6 +159,8 @@ pub struct GroupFixtureConfig {
     pub channel_count: usize,
     /// True if the fixture should be mirrored in mirror mode.
     pub mirror: bool,
+    /// Render mode index for fixtures that support more than one render mode.
+    pub render_mode: Option<RenderMode>,
 }
 
 /// Uniquely identify a specific fixture group.

--- a/src/fixture/mod.rs
+++ b/src/fixture/mod.rs
@@ -8,7 +8,7 @@ mod group;
 mod patch;
 mod profile;
 
-pub use fixture::{Control, EmitState};
+pub use fixture::{Control, EmitState, RenderMode};
 pub use group::{FixtureGroup, FixtureGroupKey, GroupName};
 pub use patch::Patch;
 pub use profile::*;
@@ -20,6 +20,8 @@ pub struct FixtureGroupControls<'a> {
     master_controls: &'a MasterControls,
     /// True if the fixture should render in mirrored mode.
     mirror: bool,
+    /// Optional render mode index for fixtures that support more than one.
+    render_mode: Option<RenderMode>,
 }
 
 impl<'a> FixtureGroupControls<'a> {
@@ -30,7 +32,7 @@ impl<'a> FixtureGroupControls<'a> {
 
 pub mod prelude {
     pub use super::fixture::{
-        AnimatedFixture, ControllableFixture, FixtureType, NonAnimatedFixture,
+        AnimatedFixture, ControllableFixture, FixtureType, NonAnimatedFixture, RenderMode,
     };
     pub use super::patch::{PatchAnimatedFixture, PatchFixture};
     pub use super::FixtureGroupControls;

--- a/src/fixture/patch.rs
+++ b/src/fixture/patch.rs
@@ -7,7 +7,7 @@ use anyhow::bail;
 use log::info;
 
 use super::fixture::{
-    AnimatedFixture, Fixture, FixtureType, FixtureWithAnimations, NonAnimatedFixture,
+    AnimatedFixture, Fixture, FixtureType, FixtureWithAnimations, NonAnimatedFixture, RenderMode,
 };
 use super::group::{FixtureGroup, FixtureGroupKey};
 use crate::channel::Channels;
@@ -136,6 +136,7 @@ impl Patch {
                 universe: cfg.universe,
                 dmx_addr: cfg.addr.map(|a| a.dmx_index()),
                 channel_count: candidate.channel_count,
+                render_mode: candidate.render_mode,
                 mirror: cfg.mirror,
             });
             return Ok(());
@@ -149,6 +150,7 @@ impl Patch {
                 universe: cfg.universe,
                 dmx_addr: cfg.addr.map(|a| a.dmx_index()),
                 channel_count: candidate.channel_count,
+                render_mode: candidate.render_mode,
                 mirror: cfg.mirror,
             },
             candidate.fixture,
@@ -238,6 +240,7 @@ impl Patch {
 pub struct PatchCandidate {
     fixture_type: FixtureType,
     channel_count: usize,
+    render_mode: Option<RenderMode>,
     fixture: Box<dyn Fixture>,
 }
 
@@ -254,9 +257,10 @@ pub trait PatchFixture: NonAnimatedFixture + Default + 'static {
                 return None;
             }
             match Self::new(options) {
-                Ok(fixture) => Some(Ok(PatchCandidate {
+                Ok((fixture, render_mode)) => Some(Ok(PatchCandidate {
                     fixture_type: Self::NAME,
-                    channel_count: fixture.channel_count(),
+                    channel_count: fixture.channel_count(render_mode),
+                    render_mode,
                     fixture: Box::new(fixture),
                 })),
                 Err(e) => Some(Err(e)),
@@ -265,13 +269,16 @@ pub trait PatchFixture: NonAnimatedFixture + Default + 'static {
     }
 
     /// The number of contiguous DMX channels used by the fixture.
-    fn channel_count(&self) -> usize;
+    ///
+    /// A render mode is provided for fixtures that may have different channel
+    /// counts for different individual specific fixtures.
+    fn channel_count(&self, render_mode: Option<RenderMode>) -> usize;
 
     /// Create a new instance of the fixture from the provided options.
     /// Non-customizable fixtures will fall back to using default.
     /// This can be overridden for fixtures that are customizable.
-    fn new(_options: &Options) -> Result<Self> {
-        Ok(Self::default())
+    fn new(_options: &Options) -> Result<(Self, Option<RenderMode>)> {
+        Ok((Self::default(), None))
     }
 }
 
@@ -286,9 +293,10 @@ pub trait PatchAnimatedFixture: AnimatedFixture + Default + 'static {
                 return None;
             }
             match Self::new(options) {
-                Ok(fixture) => Some(Ok(PatchCandidate {
+                Ok((fixture, render_mode)) => Some(Ok(PatchCandidate {
                     fixture_type: Self::NAME,
-                    channel_count: fixture.channel_count(),
+                    channel_count: fixture.channel_count(render_mode),
+                    render_mode,
                     fixture: Box::new(FixtureWithAnimations {
                         fixture,
                         animations: Default::default(),
@@ -300,12 +308,15 @@ pub trait PatchAnimatedFixture: AnimatedFixture + Default + 'static {
     }
 
     /// The number of contiguous DMX channels used by the fixture.
-    fn channel_count(&self) -> usize;
+    ///
+    /// A render mode is provided for fixtures that may have different channel
+    /// counts for different individual specific fixtures.
+    fn channel_count(&self, render_mode: Option<RenderMode>) -> usize;
 
     /// Create a new instance of the fixture from the provided options.
     /// Non-customizable fixtures will fall back to using default.
     /// This can be overridden for fixtures that are customizable.
-    fn new(_options: &Options) -> Result<Self> {
-        Ok(Self::default())
+    fn new(_options: &Options) -> Result<(Self, Option<RenderMode>)> {
+        Ok((Self::default(), None))
     }
 }

--- a/src/fixture/profile/comet.rs
+++ b/src/fixture/profile/comet.rs
@@ -32,7 +32,7 @@ const PATTERN_DMX_VALS: [u8; 10] = [12, 35, 65, 85, 112, 140, 165, 190, 212, 240
 
 impl PatchFixture for Comet {
     const NAME: FixtureType = FixtureType("Comet");
-    fn channel_count(&self) -> usize {
+    fn channel_count(&self, _render_mode: Option<RenderMode>) -> usize {
         5
     }
 }

--- a/src/fixture/profile/faderboard.rs
+++ b/src/fixture/profile/faderboard.rs
@@ -13,7 +13,7 @@ pub struct Faderboard {
 
 impl PatchFixture for Faderboard {
     const NAME: FixtureType = FixtureType("Faderboard");
-    fn channel_count(&self) -> usize {
+    fn channel_count(&self, _render_mode: Option<RenderMode>) -> usize {
         self.channel_count
     }
 }

--- a/src/fixture/profile/freedom_fries.rs
+++ b/src/fixture/profile/freedom_fries.rs
@@ -2,7 +2,7 @@
 //! Freedom Stick.
 
 //! Control profle for the Chauvet Rotosphere Q3, aka Son Of Spherion.
-use super::color::Color;
+use super::color::{Color, Model as ColorModel};
 
 use crate::fixture::prelude::*;
 
@@ -46,7 +46,8 @@ impl AnimatedFixture for FreedomFries {
             .render(animation_vals.filter(&AnimationTarget::Dimmer), dmx_buf);
         self.speed
             .render(animation_vals.filter(&AnimationTarget::Speed), dmx_buf);
-        self.color.render_without_animations(&mut dmx_buf[1..4]);
+        self.color
+            .render_without_animations(ColorModel::Rgb, &mut dmx_buf[1..4]);
         dmx_buf[4] = 0;
         self.strobe
             .render_with_group(group_controls, std::iter::empty(), dmx_buf);

--- a/src/fixture/profile/radiance.rs
+++ b/src/fixture/profile/radiance.rs
@@ -29,16 +29,16 @@ impl Default for Radiance {
 
 impl PatchAnimatedFixture for Radiance {
     const NAME: FixtureType = FixtureType("Radiance");
-    fn channel_count(&self) -> usize {
+    fn channel_count(&self, _render_mode: Option<RenderMode>) -> usize {
         2
     }
 
-    fn new(options: &HashMap<String, String>) -> Result<Self> {
+    fn new(options: &HashMap<String, String>) -> Result<(Self, Option<RenderMode>)> {
         let mut s = Self::default();
         if options.contains_key("use_timer") {
             s.timer = Some(Timer::from_options(options)?);
         }
-        Ok(s)
+        Ok((s, None))
     }
 }
 


### PR DESCRIPTION
Introduce a RenderMode index into each group fixture config, allowing fixture types to quasi-internally delegate rendering to different render models for each fixture in each group. This enables using different color targets in a single group, and most importantly, makes the leko dimmer+rotator hack actually work correctly.

channel_count is now stored in each group fixture config instead of the group itself.  render_mode is an argument when getting the initial channel_count, and is threaded into each fixture via the fixture group controls. This is actually fairly elegant!

Uses strum::VariantArray to automatically index the render model variants, and provides a helper trait EnumRenderModel to convert to/from RenderMode indices.