### PR TITLE
simplify fixture patching

### DIFF
--- a/src/fixture/mod.rs
+++ b/src/fixture/mod.rs
@@ -44,6 +44,8 @@ pub mod prelude {
     pub use crate::master::MasterControls;
     pub use crate::osc::prelude::*;
     pub use anyhow::bail;
-    pub use fixture_macros::{Control, EmitState, PatchAnimatedFixture, PatchFixture};
+    pub use fixture_macros::{
+        register_patcher, Control, EmitState, PatchAnimatedFixture, PatchFixture,
+    };
     pub use number::{BipolarFloat, Phase, UnipolarFloat};
 }

--- a/src/fixture/patch.rs
+++ b/src/fixture/patch.rs
@@ -39,22 +39,10 @@ pub struct Patch {
 
 /// Distributed registry for things that we can patch.
 ///
-/// Fixtures use the register macro to add themselves to this collection.
 /// The derive macros for the patch traits handle this.
+/// Use the register_patcher macro for fixtures that cannot derive patch.
 #[distributed_slice]
 pub static PATCHERS: [Patcher];
-
-/// Register a patcher-generating function with the patch.
-#[macro_export]
-macro_rules! register {
-    ($fixture:ty) => {
-        use linkme::distributed_slice;
-        use $crate::fixture::patch::{Patcher, PATCHERS};
-
-        #[distributed_slice(PATCHERS)]
-        static PATCHER: Patcher = <$fixture>::patch;
-    };
-}
 
 impl Patch {
     /// Initialize a new fixture patch.

--- a/src/fixture/profile/color.rs
+++ b/src/fixture/profile/color.rs
@@ -86,7 +86,7 @@ impl PatchAnimatedFixture for Color {
     }
 }
 
-crate::register!(Color);
+register_patcher!(Color);
 
 const HSLUV_LIGHTNESS_OFFSET: UnipolarFloat = UnipolarFloat::new(0.3225);
 const HSLUV_LIGHTNESS_BOOST_SCALE: UnipolarFloat = UnipolarFloat::new(1.0 - 0.3225);

--- a/src/fixture/profile/comet.rs
+++ b/src/fixture/profile/comet.rs
@@ -37,7 +37,7 @@ impl PatchFixture for Comet {
     }
 }
 
-crate::register!(Comet);
+register_patcher!(Comet);
 
 impl NonAnimatedFixture for Comet {
     fn render(&self, _group_controls: &FixtureGroupControls, dmx_buf: &mut [u8]) {

--- a/src/fixture/profile/faderboard.rs
+++ b/src/fixture/profile/faderboard.rs
@@ -18,7 +18,7 @@ impl PatchFixture for Faderboard {
     }
 }
 
-crate::register!(Faderboard);
+register_patcher!(Faderboard);
 
 const DEFAULT_CHANNEL_COUNT: usize = 16;
 

--- a/src/fixture/profile/leko.rs
+++ b/src/fixture/profile/leko.rs
@@ -55,7 +55,7 @@ impl PatchAnimatedFixture for Leko {
     }
 }
 
-crate::register!(Leko);
+register_patcher!(Leko);
 
 impl AnimatedFixture for Leko {
     type Target = AnimationTarget;

--- a/src/fixture/profile/radiance.rs
+++ b/src/fixture/profile/radiance.rs
@@ -42,7 +42,7 @@ impl PatchAnimatedFixture for Radiance {
     }
 }
 
-crate::register!(Radiance);
+register_patcher!(Radiance);
 
 impl AnimatedFixture for Radiance {
     type Target = AnimationTarget;


### PR DESCRIPTION
Simplify how we declare and register patchers.

- Make PATCHERS a collection of direct patcher functions, eliminating the closure indirection that we no longer need.
- Lift the patcher registration macro up into the rest of the proc macros, and directly re-use the implementation in the derive macros.
