### PR TITLE
revamp patch format

### DIFF
--- a/patch/test.yaml
+++ b/patch/test.yaml
@@ -4,3 +4,4 @@
     count: 64
   options:
     control_color_space: Hsluv
+    model: foobar

--- a/patch/test.yaml
+++ b/patch/test.yaml
@@ -2,6 +2,5 @@
   addr:
     start: 1
     count: 64
-  channel: True
   options:
     control_color_space: Hsluv

--- a/patch/test.yaml
+++ b/patch/test.yaml
@@ -1,4 +1,4 @@
-- name: Color
+- fixture: Color
   addr:
     start: 1
     count: 64

--- a/patch/test.yaml
+++ b/patch/test.yaml
@@ -4,4 +4,3 @@
     count: 64
   options:
     control_color_space: Hsluv
-    model: foobar

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,10 @@ pub enum DmxAddrConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct FixtureGroupConfig {
-    pub name: String,
+    /// The type of fixture to patch.
+    pub fixture: String,
     /// The DMX address configuration to patch this fixture at.
-    /// If no address it provided, assume this fixture doesn't need to render.
+    /// If no address is provided, assume this fixture doesn't need to render.
     #[serde(default)]
     pub addr: Option<DmxAddrConfig>,
     /// The universe this fixture is patched in.
@@ -81,7 +82,7 @@ pub struct FixtureConfig {
 impl FixtureConfig {
     fn from_group_config(group: &FixtureGroupConfig, addr: Option<DmxAddr>) -> Self {
         Self {
-            name: group.name.clone(),
+            name: group.fixture.clone(),
             addr,
             universe: group.universe,
             mirror: group.mirror,

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,7 +62,8 @@ impl FixtureGroupConfig {
 /// A single instance of a fixture to patch, produced by a FixtureGroupConfig.
 #[derive(Clone, Debug)]
 pub struct FixtureConfig {
-    pub name: String,
+    /// The type of fixture to patch.
+    pub fixture: String,
     /// The DMX address to patch this fixture at.
     /// If no address it provided, assume this fixture doesn't need to render.
     pub addr: Option<DmxAddr>,
@@ -82,7 +83,7 @@ pub struct FixtureConfig {
 impl FixtureConfig {
     fn from_group_config(group: &FixtureGroupConfig, addr: Option<DmxAddr>) -> Self {
         Self {
-            name: group.fixture.clone(),
+            fixture: group.fixture.clone(),
             addr,
             universe: group.universe,
             mirror: group.mirror,

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,9 +33,13 @@ pub struct FixtureGroupConfig {
     /// Additional key-value string options for configuring specific fixture types.
     #[serde(default)]
     pub options: Options,
-    /// If true, assign to a channel.
-    #[serde(default)]
+    /// If true, assign to a channel. Defaults to true.
+    #[serde(default = "_true")]
     pub channel: bool,
+}
+
+const fn _true() -> bool {
+    true
 }
 
 impl FixtureGroupConfig {

--- a/src/fixture/patch.rs
+++ b/src/fixture/patch.rs
@@ -69,7 +69,7 @@ impl Patch {
 
     /// Patch a fixture group config - either a single address or a range.
     pub fn patch(&mut self, cfg: FixtureGroupConfig) -> anyhow::Result<()> {
-        let candidate = self.get_candidate(&cfg.name, &cfg.options)?;
+        let candidate = self.get_candidate(&cfg.fixture, &cfg.options)?;
         for fixture_cfg in cfg.fixture_configs(candidate.channel_count) {
             self.patch_one(fixture_cfg)?;
         }

--- a/src/fixture/profile/color.rs
+++ b/src/fixture/profile/color.rs
@@ -1,8 +1,4 @@
 //! Flexible control profile for a single-color fixture.
-//! Supports several color space options:
-
-use std::collections::HashMap;
-
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
 use hsluv::hsluv_to_rgb;
@@ -10,6 +6,7 @@ use log::{error, warn};
 use strum_macros::{EnumString, VariantArray};
 
 use crate::{
+    config::Options,
     fixture::{fixture::EnumRenderModel, prelude::*},
     osc::OscControlMessage,
 };
@@ -56,9 +53,9 @@ impl PatchAnimatedFixture for Color {
         Model::model_for_mode(render_mode).unwrap().channel_count()
     }
 
-    fn new(options: &HashMap<String, String>) -> Result<(Self, Option<RenderMode>)> {
+    fn new(options: &mut Options) -> Result<(Self, Option<RenderMode>)> {
         let render_mode = options
-            .get("kind")
+            .remove("kind")
             .map(|kind| {
                 kind.parse::<Model>()
                     .with_context(|| format!("unknown color output model \"{kind}\""))
@@ -67,7 +64,7 @@ impl PatchAnimatedFixture for Color {
             .unwrap_or_default()
             .render_mode();
         let space = options
-            .get("control_color_space")
+            .remove("control_color_space")
             .map(|space| {
                 space
                     .parse::<ColorSpace>()

--- a/src/fixture/profile/leko.rs
+++ b/src/fixture/profile/leko.rs
@@ -45,12 +45,12 @@ impl PatchAnimatedFixture for Leko {
         Model::model_for_mode(render_mode).unwrap().channel_count()
     }
 
-    fn new(options: &crate::config::Options) -> anyhow::Result<(Self, Option<RenderMode>)> {
-        let Some(kind) = options.get("kind") else {
-            bail!("lekos must specify the \"kind\" option");
+    fn new(options: &mut crate::config::Options) -> anyhow::Result<(Self, Option<RenderMode>)> {
+        let Some(kind) = options.remove("kind") else {
+            bail!("missing required option: kind");
         };
         let model =
-            Model::from_str(kind).with_context(|| format!("invalid leko kind: \"{kind}\""))?;
+            Model::from_str(&kind).with_context(|| format!("invalid kind option: {kind}"))?;
         Ok((Default::default(), Some(model.render_mode())))
     }
 }

--- a/src/fixture/profile/radiance.rs
+++ b/src/fixture/profile/radiance.rs
@@ -1,9 +1,9 @@
 //! Control profile for a Radiance hazer.
 //! Probably fine for any generic 2-channel hazer.
 use anyhow::Result;
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
-use crate::fixture::prelude::*;
+use crate::{config::Options, fixture::prelude::*};
 
 #[derive(Debug, EmitState, Control)]
 pub struct Radiance {
@@ -33,9 +33,9 @@ impl PatchAnimatedFixture for Radiance {
         2
     }
 
-    fn new(options: &HashMap<String, String>) -> Result<(Self, Option<RenderMode>)> {
+    fn new(options: &mut Options) -> Result<(Self, Option<RenderMode>)> {
         let mut s = Self::default();
-        if options.contains_key("use_timer") {
+        if options.remove("use_timer").is_some() {
             s.timer = Some(Timer::from_options(options)?);
         }
         Ok((s, None))


### PR DESCRIPTION
- **Make channel default to true since most things want to be on channels.**
- **Rename name to fixture for patch format.**
- **Make patchers consume options and ensure they used them all.**
