### PR TITLE
channels dont need animation

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -233,7 +233,7 @@ impl Channels {
                         entity: crate::osc::animation::GROUP,
                         emitter,
                     },
-                )?;
+                );
             }
             ControlMessage::Control { channel_id, msg } => {
                 let channel_id = if let Some(id) = channel_id {

--- a/src/fixture/fixture.rs
+++ b/src/fixture/fixture.rs
@@ -141,9 +141,6 @@ pub trait Fixture: ControllableFixture {
         dmx_buffer: &mut [u8],
     );
 
-    /// Return true if this fixture has animations.
-    fn is_animated(&self) -> bool;
-
     /// Get the animation with the provided index.
     fn get_animation(&self, index: usize) -> Option<&dyn ControllableTargetedAnimation>;
 
@@ -164,10 +161,6 @@ where
         dmx_buffer: &mut [u8],
     ) {
         self.render(group_controls, dmx_buffer)
-    }
-
-    fn is_animated(&self) -> bool {
-        false
     }
 
     fn get_animation_mut(
@@ -247,10 +240,6 @@ impl<F: AnimatedFixture> Fixture for FixtureWithAnimations<F> {
             TargetedAnimationValues(&animation_vals),
             dmx_buffer,
         );
-    }
-
-    fn is_animated(&self) -> bool {
-        true
     }
 
     fn get_animation_mut(

--- a/src/fixture/patch.rs
+++ b/src/fixture/patch.rs
@@ -66,14 +66,6 @@ impl Patch {
     pub fn patch(&mut self, cfg: FixtureGroupConfig) -> anyhow::Result<()> {
         let candidate = self.get_candidate(&cfg.fixture, &cfg.options)?;
 
-        if cfg.channel {
-            ensure!(
-                candidate.fixture.is_animated(),
-                "cannot assign non-animatable fixture {} to a channel",
-                candidate.fixture_type
-            );
-        }
-
         for fixture_cfg in cfg.fixture_configs(candidate.channel_count) {
             let key = self.patch_one(fixture_cfg)?;
             if cfg.channel {

--- a/src/fixture/profile/rug_doctor.rs
+++ b/src/fixture/profile/rug_doctor.rs
@@ -5,11 +5,10 @@ use crate::{
 };
 use wled_json_api_library::structures::state::{Seg, State};
 
-#[derive(Debug, EmitState, Control, PatchAnimatedFixture)]
+#[derive(Debug, EmitState, Control, PatchFixture)]
 #[channel_count = 0]
 pub struct RugDoctor {
     #[channel_control]
-    #[animate] // FIXME animations aren't actually used, need to fix channel patching
     #[on_change = "update_level"]
     level: ChannelLevelUnipolar<Unipolar<()>>,
     #[channel_control]
@@ -33,16 +32,8 @@ impl Default for RugDoctor {
     }
 }
 
-impl AnimatedFixture for RugDoctor {
-    type Target = AnimationTarget;
-
-    fn render_with_animations(
-        &self,
-        _group_controls: &FixtureGroupControls,
-        _animation_vals: TargetedAnimationValues<Self::Target>,
-        _dmx_buf: &mut [u8],
-    ) {
-    }
+impl NonAnimatedFixture for RugDoctor {
+    fn render(&self, _: &FixtureGroupControls, _: &mut [u8]) {}
 }
 
 impl ControllableFixture for RugDoctor {}

--- a/src/show.rs
+++ b/src/show.rs
@@ -352,7 +352,7 @@ impl Show {
                     entity: crate::osc::animation::GROUP,
                     emitter,
                 },
-            )?;
+            );
         }
 
         self.clocks.emit_state(&mut self.controller);


### PR DESCRIPTION
Remove the requirement that a fixture patched onto a channel must have animations. Use a fixed empty placeholder to update the UI, including a blank collection of animation targets.  This pretty much works.
