### PR TITLE
streamline subfixtures with animations

### DIFF
--- a/src/fixture/fixture.rs
+++ b/src/fixture/fixture.rs
@@ -121,7 +121,7 @@ pub trait AnimatedFixture: ControllableFixture {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     );
 }
@@ -238,7 +238,7 @@ impl<F: AnimatedFixture> Fixture for FixtureWithAnimations<F> {
         }
         self.fixture.render_with_animations(
             group_controls,
-            TargetedAnimationValues(&animation_vals),
+            &TargetedAnimationValues(animation_vals),
             dmx_buffer,
         );
     }

--- a/src/fixture/mod.rs
+++ b/src/fixture/mod.rs
@@ -43,7 +43,7 @@ pub mod prelude {
     pub use super::FixtureGroupControls;
     pub use crate::channel::ChannelStateEmitter;
     pub use crate::control::EmitControlMessage;
-    pub use crate::fixture::animation_target::TargetedAnimationValues;
+    pub use crate::fixture::animation_target::{Subtarget, TargetedAnimationValues};
     pub use crate::fixture::control::*;
     pub use crate::fixture::generic::*;
     pub use crate::master::MasterControls;

--- a/src/fixture/profile/aquarius.rs
+++ b/src/fixture/profile/aquarius.rs
@@ -28,7 +28,7 @@ impl AnimatedFixture for Aquarius {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.rotation

--- a/src/fixture/profile/astera.rs
+++ b/src/fixture/profile/astera.rs
@@ -70,7 +70,7 @@ impl AnimatedFixture for Astera {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.dimmer.render_with_group(

--- a/src/fixture/profile/astroscan.rs
+++ b/src/fixture/profile/astroscan.rs
@@ -75,7 +75,7 @@ impl AnimatedFixture for Astroscan {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.iris

--- a/src/fixture/profile/color.rs
+++ b/src/fixture/profile/color.rs
@@ -130,7 +130,7 @@ impl Color {
         &self,
         model: Model,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<AnimationTarget>,
+        animation_vals: &TargetedAnimationValues<AnimationTarget>,
         dmx_buf: &mut [u8],
     ) {
         // If a color override has been provided, render it scaled by the level.
@@ -179,7 +179,7 @@ impl AnimatedFixture for Color {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         let model = match Model::model_for_mode(group_controls.render_mode) {

--- a/src/fixture/profile/colordynamic.rs
+++ b/src/fixture/profile/colordynamic.rs
@@ -47,7 +47,7 @@ impl AnimatedFixture for Colordynamic {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         dmx_buf[0] = 0; // FIXME does this do anything?

--- a/src/fixture/profile/cosmic_burst.rs
+++ b/src/fixture/profile/cosmic_burst.rs
@@ -30,7 +30,7 @@ impl AnimatedFixture for CosmicBurst {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.dimmer

--- a/src/fixture/profile/dimmer.rs
+++ b/src/fixture/profile/dimmer.rs
@@ -23,7 +23,7 @@ impl AnimatedFixture for Dimmer {
     fn render_with_animations(
         &self,
         _group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.level.render(animation_vals.all(), dmx_buf);

--- a/src/fixture/profile/freedom_fries.rs
+++ b/src/fixture/profile/freedom_fries.rs
@@ -38,7 +38,7 @@ impl AnimatedFixture for FreedomFries {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.dimmer

--- a/src/fixture/profile/freq_strobe.rs
+++ b/src/fixture/profile/freq_strobe.rs
@@ -67,7 +67,7 @@ impl AnimatedFixture for FreqStrobe {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.flasher.render(group_controls, dmx_buf);

--- a/src/fixture/profile/fusion_roll.rs
+++ b/src/fixture/profile/fusion_roll.rs
@@ -71,7 +71,7 @@ impl AnimatedFixture for FusionRoll {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.drum_swivel.render_with_group(

--- a/src/fixture/profile/h2o.rs
+++ b/src/fixture/profile/h2o.rs
@@ -57,7 +57,7 @@ impl AnimatedFixture for H2O {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.dimmer.render_with_group(

--- a/src/fixture/profile/hypnotic.rs
+++ b/src/fixture/profile/hypnotic.rs
@@ -34,7 +34,7 @@ impl AnimatedFixture for Hypnotic {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         dmx_buf[0] = if !self.on.control.val() {

--- a/src/fixture/profile/iwash_led.rs
+++ b/src/fixture/profile/iwash_led.rs
@@ -33,7 +33,7 @@ impl AnimatedFixture for IWashLed {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.pan.render_with_group(
@@ -53,7 +53,7 @@ impl AnimatedFixture for IWashLed {
         self.color.render_for_model(
             ColorRenderModel::Rgb,
             group_controls,
-            TargetedAnimationValues(&animation_vals.subtarget()),
+            &animation_vals.subtarget(),
             &mut dmx_buf[7..10],
         );
         dmx_buf[10] = 0; // useless single white diode "color balance"

--- a/src/fixture/profile/iwash_led.rs
+++ b/src/fixture/profile/iwash_led.rs
@@ -2,7 +2,7 @@
 //!
 //! The alien egg sack with the most pastel blue diode of them all. Bleh.
 use crate::fixture::{
-    color::{AnimationTarget as ColorAnimationTarget, Color, Model as ColorRenderModel},
+    color::{Color, Model as ColorRenderModel},
     prelude::*,
 };
 
@@ -10,8 +10,11 @@ use crate::fixture::{
 #[channel_count = 12]
 pub struct IWashLed {
     #[channel_control]
+    #[animate_subtarget(Hue, Sat, Val)]
     color: Color,
+    #[animate]
     pan: Mirrored<RenderBipolarToCoarseAndFine>,
+    #[animate]
     tilt: Mirrored<RenderBipolarToCoarseAndFine>,
 }
 
@@ -58,37 +61,5 @@ impl AnimatedFixture for IWashLed {
         );
         dmx_buf[10] = 0; // useless single white diode "color balance"
         dmx_buf[11] = 0; // fixture reset if set in 101-170
-    }
-}
-
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    PartialEq,
-    strum_macros::EnumString,
-    strum_macros::EnumIter,
-    strum_macros::Display,
-    num_derive::FromPrimitive,
-    num_derive::ToPrimitive,
-)]
-pub enum AnimationTarget {
-    #[default]
-    Hue,
-    Sat,
-    Val,
-    Pan,
-    Tilt,
-}
-
-impl Subtarget<ColorAnimationTarget> for AnimationTarget {
-    fn as_subtarget(&self) -> Option<ColorAnimationTarget> {
-        match *self {
-            Self::Hue => Some(ColorAnimationTarget::Hue),
-            Self::Sat => Some(ColorAnimationTarget::Sat),
-            Self::Val => Some(ColorAnimationTarget::Val),
-            _ => None,
-        }
     }
 }

--- a/src/fixture/profile/leko.rs
+++ b/src/fixture/profile/leko.rs
@@ -74,7 +74,7 @@ impl AnimatedFixture for Leko {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         let model = match Model::model_for_mode(group_controls.render_mode) {

--- a/src/fixture/profile/radiance.rs
+++ b/src/fixture/profile/radiance.rs
@@ -50,7 +50,7 @@ impl AnimatedFixture for Radiance {
     fn render_with_animations(
         &self,
         _group_controls: &FixtureGroupControls,
-        _animation_vals: TargetedAnimationValues<Self::Target>,
+        _animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         if let Some(timer) = self.timer.as_ref() {

--- a/src/fixture/profile/rotosphere_q3.rs
+++ b/src/fixture/profile/rotosphere_q3.rs
@@ -42,7 +42,7 @@ impl AnimatedFixture for RotosphereQ3 {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         Rgbw.render(

--- a/src/fixture/profile/rush_wizard.rs
+++ b/src/fixture/profile/rush_wizard.rs
@@ -79,7 +79,7 @@ impl AnimatedFixture for RushWizard {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.strobe

--- a/src/fixture/profile/solar_system.rs
+++ b/src/fixture/profile/solar_system.rs
@@ -46,7 +46,7 @@ impl AnimatedFixture for SolarSystem {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.front_gobo.render_no_anim(dmx_buf);

--- a/src/fixture/profile/starlight.rs
+++ b/src/fixture/profile/starlight.rs
@@ -30,7 +30,7 @@ impl AnimatedFixture for Starlight {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         dmx_buf[0] = 255; // DMX mode

--- a/src/fixture/profile/ufo.rs
+++ b/src/fixture/profile/ufo.rs
@@ -41,7 +41,7 @@ impl AnimatedFixture for Ufo {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.pan.render_with_group(
@@ -66,7 +66,7 @@ impl AnimatedFixture for Ufo {
         self.color.render_for_model(
             ColorRenderModel::Rgbw,
             group_controls,
-            TargetedAnimationValues(&animation_vals.subtarget()),
+            &animation_vals.subtarget(),
             &mut dmx_buf[8..12],
         );
 

--- a/src/fixture/profile/ufo.rs
+++ b/src/fixture/profile/ufo.rs
@@ -4,7 +4,7 @@
 //! plus the ability to animate them, for now. Might be nice to try an XY pad,
 //! but that would require defining a new OSC control type.
 use crate::fixture::{
-    color::{AnimationTarget as ColorAnimationTarget, Color, Model as ColorRenderModel},
+    color::{Color, Model as ColorRenderModel},
     prelude::*,
 };
 
@@ -12,10 +12,14 @@ use crate::fixture::{
 #[channel_count = 16]
 pub struct Ufo {
     #[channel_control]
+    #[animate_subtarget(Hue, Sat, Val)]
     color: Color,
     #[channel_control]
+    #[animate]
     rotation: ChannelKnobBipolar<BipolarSplitChannelMirror>,
+    #[animate]
     pan: Mirrored<RenderBipolarToCoarseAndFine>,
+    #[animate]
     tilt: Mirrored<RenderBipolarToCoarseAndFine>,
 }
 
@@ -79,38 +83,5 @@ impl AnimatedFixture for Ufo {
         // TODO: this might be a useful feature to implement if their motion
         // tends to run out of calibration
         dmx_buf[15] = 0;
-    }
-}
-
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    PartialEq,
-    strum_macros::EnumString,
-    strum_macros::EnumIter,
-    strum_macros::Display,
-    num_derive::FromPrimitive,
-    num_derive::ToPrimitive,
-)]
-pub enum AnimationTarget {
-    #[default]
-    Hue,
-    Sat,
-    Val,
-    Rotation,
-    Pan,
-    Tilt,
-}
-
-impl Subtarget<ColorAnimationTarget> for AnimationTarget {
-    fn as_subtarget(&self) -> Option<ColorAnimationTarget> {
-        match *self {
-            Self::Hue => Some(ColorAnimationTarget::Hue),
-            Self::Sat => Some(ColorAnimationTarget::Sat),
-            Self::Val => Some(ColorAnimationTarget::Val),
-            _ => None,
-        }
     }
 }

--- a/src/fixture/profile/uv_led_brick.rs
+++ b/src/fixture/profile/uv_led_brick.rs
@@ -23,7 +23,7 @@ impl AnimatedFixture for UvLedBrick {
     fn render_with_animations(
         &self,
         _group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.level.render(animation_vals.all(), dmx_buf);

--- a/src/fixture/profile/wizard_extreme.rs
+++ b/src/fixture/profile/wizard_extreme.rs
@@ -74,7 +74,7 @@ impl AnimatedFixture for WizardExtreme {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.shutter.render_with_group(

--- a/src/fixture/profile/wizlet.rs
+++ b/src/fixture/profile/wizlet.rs
@@ -74,7 +74,7 @@ impl AnimatedFixture for Wizlet {
     fn render_with_animations(
         &self,
         group_controls: &FixtureGroupControls,
-        animation_vals: TargetedAnimationValues<Self::Target>,
+        animation_vals: &TargetedAnimationValues<Self::Target>,
         dmx_buf: &mut [u8],
     ) {
         self.drum_swivel.render_with_group(


### PR DESCRIPTION
Support animations on subfixtures defined as controls via a new `#[animate_subtarget(...)]` attribute on the `Control` derive macro. This automatically generates target types in the fixture for the named attributes, and implements a conversion trait that allows a simple method call to pass a filtered set of targeted animations to a subfixture.

A bit of refactoring to enable this - TargetedAnimationValues now itself owns a fixed-size array, and is passed around by reference. This allows returning a new instance of this from the new `subtarget` convenience method.
