### PR TITLE
Implement HSI color space.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -224,6 +224,7 @@ pub fn hsv_to_rgb(hue: Phase, sat: UnipolarFloat, val: UnipolarFloat) -> ColorRg
 ///
 /// Ported from https://blog.saikoled.com/post/43693602826/why-every-led-light-should-be-using-hsi
 pub fn hsi_to_rgb(hue: Phase, sat: UnipolarFloat, intensity: UnipolarFloat) -> ColorRgb {
+    let hue = hue + 1. / 3.;
     let (rv, gv, bv) = if hue.val() < 1. / 3. {
         let hue_rad = 2. * PI * hue.val();
         (
@@ -266,6 +267,7 @@ pub fn hsi_to_rgb(hue: Phase, sat: UnipolarFloat, intensity: UnipolarFloat) -> C
 ///
 /// Ported from https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
 pub fn hsi_to_rgbw(hue: Phase, sat: UnipolarFloat, intensity: UnipolarFloat) -> ColorRgbw {
+    let hue = hue + 1. / 3.;
     let (rv, gv, bv) = if hue.val() < 1. / 3. {
         let hue_rad = 2. * PI * hue.val();
         let cos_h = hue_rad.cos();

--- a/src/fixture/profile/color.rs
+++ b/src/fixture/profile/color.rs
@@ -111,6 +111,14 @@ impl Color {
                     val: self.val.control.val(),
                 },
             ),
+            ColorSpace::Hsi => model.render(
+                dmx_buf,
+                Hsi {
+                    hue: self.hue.control.val(),
+                    sat: self.sat.control.val(),
+                    intensity: self.val.control.val(),
+                },
+            ),
             ColorSpace::Hsluv => model.render(
                 dmx_buf,
                 Hsluv {
@@ -160,6 +168,14 @@ impl Color {
                     hue: Phase::new(hue),
                     sat: UnipolarFloat::new(sat),
                     val: UnipolarFloat::new(val),
+                },
+            ),
+            ColorSpace::Hsi => model.render(
+                dmx_buf,
+                Hsi {
+                    hue: Phase::new(hue),
+                    sat: UnipolarFloat::new(sat),
+                    intensity: UnipolarFloat::new(val),
                 },
             ),
             ColorSpace::Hsluv => model.render(

--- a/src/fixture/profile/ufo.rs
+++ b/src/fixture/profile/ufo.rs
@@ -26,7 +26,7 @@ pub struct Ufo {
 impl Default for Ufo {
     fn default() -> Self {
         Self {
-            color: Color::for_subcontrol(None, crate::color::ColorSpace::Hsv),
+            color: Color::for_subcontrol(None, crate::color::ColorSpace::Hsi),
             rotation: Bipolar::split_channel("Rotation", 5, 191, 128, 192, 255, 0)
                 .with_detent()
                 .with_mirroring(true)


### PR DESCRIPTION
Implement HSI color space, including conversions to RGB and RGBW. The RGBW conversion does a nice job of using the diodes, resulting in more uniform brightness between primaries and secondaries compared to HSV, never uses more than two color diodes at once, and only uses white when fully desaturated.

Swaps the Ufo to use HSI instead of HSV.

Implementation ported from https://blog.saikoled.com