### PR TITLE
Refactor how patch is stored; use group UUIDs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "tunnels_lib",
  "typetag",
  "url",
+ "uuid",
  "wled-json-api-library",
  "zero_configure",
  "zip",
@@ -5947,6 +5948,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,6 @@ dependencies = [
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "ordered-float",
- "ordermap",
  "owo-colors",
  "quick-xml 0.37.5",
  "rand 0.9.2",
@@ -4097,15 +4096,6 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "ordermap"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
-dependencies = [
- "indexmap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ hsluv = "0.3"
 clap = { version = "4", features = ["derive"] }
 num-derive = "0.4"
 ordered-float = "5"
-ordermap = "1"
 ansi-escapes = "0.2.0"
 egui_plot = "0.34"
 eframe = "0.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tiny_http = "0.12"
 mdns-sd = "0.13"
 gethostname = "1"
 rfd = "0.15"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -9,9 +9,9 @@ use crate::{
     fixture::{
         FixtureGroup,
         animation_target::{AnimationTargetIndex, ControllableTargetedAnimation, N_ANIM},
+        patch::ChannelId,
     },
     osc::{GroupControlMap, OscControlMessage},
-    show::ChannelId,
 };
 
 pub struct AnimationUIState {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -4,48 +4,16 @@
 //! per-show selection state ("which channel is the operator focused on?") and
 //! the OSC control handlers that route channel-scoped messages.
 
-use std::fmt::Display;
-
 use anyhow::{Result, anyhow, bail};
 use log::{debug, error};
 use number::{BipolarFloat, UnipolarFloat};
-use serde::Deserialize;
 
 use crate::{
     animation::AnimationUIState,
     control::EmitControlMessage,
-    fixture::Patch,
+    fixture::{Patch, patch::ChannelId},
     osc::{EmitOscMessage, GroupControlMap, OscControlMessage, ScopedControlEmitter},
 };
-
-/// The index of a channel within the patch's channel-bound groups.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize)]
-pub struct ChannelId(usize);
-
-impl ChannelId {
-    /// Construct a `ChannelId` from a raw index. The caller is responsible for
-    /// ensuring it's in range for the current patch; use
-    /// [`Patch::validate_channel`] to validate untrusted indices.
-    pub fn new(index: usize) -> Self {
-        Self(index)
-    }
-
-    pub fn inner(&self) -> usize {
-        self.0
-    }
-}
-
-impl From<ChannelId> for usize {
-    fn from(value: ChannelId) -> Self {
-        value.0
-    }
-}
-
-impl Display for ChannelId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 /// OSC dispatch and selection state for channels.
 pub struct Channels {
@@ -60,9 +28,8 @@ impl Channels {
     pub fn new(patch: &Patch) -> Self {
         let mut controls = GroupControlMap::default();
         Self::map_controls(&mut controls);
-        let current_channel = (patch.channel_count() > 0).then(|| ChannelId::new(0));
         Self {
-            current_channel,
+            current_channel: patch.first_channel(),
             controls,
         }
     }
@@ -77,8 +44,7 @@ impl Channels {
     pub fn reconcile_to_patch(&mut self, patch: &Patch) {
         self.current_channel = match self.current_channel {
             Some(ch) if ch.inner() < patch.channel_count() => Some(ch),
-            _ if patch.channel_count() > 0 => Some(ChannelId::new(0)),
-            _ => None,
+            _ => patch.first_channel(),
         };
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2,14 +2,14 @@
 
 use std::{collections::HashMap, fmt::Display};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, anyhow, bail};
 use log::{debug, error};
 use number::{BipolarFloat, UnipolarFloat};
 use serde::Deserialize;
 
 use crate::{
     animation::AnimationUIState,
-    config::FixtureGroupKey,
+    config::GroupId,
     control::EmitControlMessage,
     fixture::{FixtureGroup, Patch},
     osc::{EmitOscMessage, GroupControlMap, OscControlMessage, ScopedControlEmitter},
@@ -38,10 +38,10 @@ impl Display for ChannelId {
 }
 
 pub struct Channels {
-    /// Lookup from channel index to the fixture group assigned to that channel.
-    channel_index: Vec<FixtureGroupKey>,
-    /// Reverse-lookup from fixture group key to channel index.
-    fixture_channel_index: HashMap<FixtureGroupKey, ChannelId>,
+    /// Lookup from channel index to the stable id of the fixture group on that channel.
+    channel_index: Vec<GroupId>,
+    /// Reverse-lookup from stable group id to channel index.
+    fixture_channel_index: HashMap<GroupId, ChannelId>,
     /// The channel ID that is currently selected.
     current_channel: Option<ChannelId>,
     controls: GroupControlMap<ControlMessage>,
@@ -59,18 +59,18 @@ impl Channels {
         }
     }
 
-    pub fn from_iter(keys: impl IntoIterator<Item = FixtureGroupKey>) -> Self {
+    pub fn from_iter(ids: impl IntoIterator<Item = GroupId>) -> Self {
         let mut c = Self::new();
-        for k in keys {
-            c.add(k);
+        for id in ids {
+            c.add(id);
         }
         c
     }
 
-    /// Add new channel controls, wired to the specified fixture.
-    pub fn add(&mut self, group: FixtureGroupKey) -> ChannelId {
+    /// Add new channel controls, wired to the specified fixture group.
+    pub fn add(&mut self, group: GroupId) -> ChannelId {
         let id = ChannelId(self.channel_index.len());
-        self.channel_index.push(group.clone());
+        self.channel_index.push(group);
         self.fixture_channel_index.insert(group, id);
         // If this is the first channel we're configuring, set it as selected.
         if self.current_channel.is_none() {
@@ -104,19 +104,26 @@ impl Channels {
         }
     }
 
-    /// Look up a channel ID by fixture group key.
-    pub fn channel_for_fixture(&self, group: &str) -> Option<ChannelId> {
-        self.fixture_channel_index.get(group).cloned()
+    /// Look up a channel ID by the fixture group's stable identity.
+    pub fn channel_for_id(&self, group: GroupId) -> Option<ChannelId> {
+        self.fixture_channel_index.get(&group).cloned()
     }
 
-    /// Iterate over all of the labels for each channels.
+    /// Look up a channel ID by the fixture group's display name. For OSC entry
+    /// points where the address provides a name string.
+    pub fn channel_for_name(&self, name: &str, patch: &Patch) -> Option<ChannelId> {
+        let group = patch.get(name).ok()?;
+        self.channel_for_id(group.id())
+    }
+
+    /// Iterate over all of the labels for each channel.
     pub fn channel_labels<'a>(&'a self, patch: &'a Patch) -> impl Iterator<Item = String> + 'a {
         self.channel_index
             .iter()
-            .filter_map(|i| match patch.get(i) {
-                Ok(f) => Some(f),
-                Err(err) => {
-                    error!("Patch inconsistency generating channel labels: {err}");
+            .filter_map(|id| match patch.get_by_id(*id) {
+                Some(f) => Some(f),
+                None => {
+                    error!("Patch inconsistency generating channel labels: missing group {id}");
                     None
                 }
             })
@@ -129,12 +136,12 @@ impl Channels {
         patch: &'a Patch,
         channel: ChannelId,
     ) -> Result<&'a FixtureGroup> {
-        let Some(fixture_key) = self.channel_index.get(channel.0) else {
+        let Some(group_id) = self.channel_index.get(channel.0) else {
             bail!("tried to get out-of-range channel {channel}");
         };
         patch
-            .get(fixture_key)
-            .with_context(|| format!("channel {channel}"))
+            .get_by_id(*group_id)
+            .ok_or_else(|| anyhow!("channel {channel}: group {group_id} not in patch"))
     }
 
     /// Get a fixture group by channel ID, mutably.
@@ -143,12 +150,12 @@ impl Channels {
         patch: &'a mut Patch,
         channel: ChannelId,
     ) -> Result<&'a mut FixtureGroup> {
-        let Some(fixture_key) = self.channel_index.get(channel.0) else {
+        let Some(group_id) = self.channel_index.get(channel.0).copied() else {
             bail!("tried to get out-of-range channel {channel}");
         };
         patch
-            .get_mut(fixture_key)
-            .with_context(|| format!("channel {channel}"))
+            .get_mut_by_id(group_id)
+            .ok_or_else(|| anyhow!("channel {channel}: group {group_id} not in patch"))
     }
 
     pub fn current_channel(&self) -> Option<ChannelId> {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,10 @@
-//! State and control definitions for fixture group channels.
+//! Selection state and OSC dispatch for fixture group channels.
+//!
+//! Channel storage itself lives on `Patch` — this module only holds the
+//! per-show selection state ("which channel is the operator focused on?") and
+//! the OSC control handlers that route channel-scoped messages.
 
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
 use anyhow::{Result, anyhow, bail};
 use log::{debug, error};
@@ -9,17 +13,23 @@ use serde::Deserialize;
 
 use crate::{
     animation::AnimationUIState,
-    config::GroupId,
     control::EmitControlMessage,
-    fixture::{FixtureGroup, Patch},
+    fixture::Patch,
     osc::{EmitOscMessage, GroupControlMap, OscControlMessage, ScopedControlEmitter},
 };
 
-/// The index of a channel.
+/// The index of a channel within the patch's channel-bound groups.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize)]
 pub struct ChannelId(usize);
 
 impl ChannelId {
+    /// Construct a `ChannelId` from a raw index. The caller is responsible for
+    /// ensuring it's in range for the current patch; use
+    /// [`Patch::validate_channel`] to validate untrusted indices.
+    pub fn new(index: usize) -> Self {
+        Self(index)
+    }
+
     pub fn inner(&self) -> usize {
         self.0
     }
@@ -37,129 +47,41 @@ impl Display for ChannelId {
     }
 }
 
+/// OSC dispatch and selection state for channels. Channel membership and
+/// channel→group lookups live on `Patch`; this struct just remembers which
+/// channel is currently selected and routes incoming channel control messages.
 pub struct Channels {
-    /// Lookup from channel index to the stable id of the fixture group on that channel.
-    channel_index: Vec<GroupId>,
-    /// Reverse-lookup from stable group id to channel index.
-    fixture_channel_index: HashMap<GroupId, ChannelId>,
     /// The channel ID that is currently selected.
     current_channel: Option<ChannelId>,
     controls: GroupControlMap<ControlMessage>,
 }
 
 impl Channels {
-    pub fn new() -> Self {
+    /// Build a `Channels` for a patch. If the patch has any channels, the
+    /// first one is selected by default.
+    pub fn new(patch: &Patch) -> Self {
         let mut controls = GroupControlMap::default();
         Self::map_controls(&mut controls);
+        let current_channel = (patch.channel_count() > 0).then(|| ChannelId::new(0));
         Self {
-            channel_index: Default::default(),
-            fixture_channel_index: Default::default(),
-            current_channel: Default::default(),
+            current_channel,
             controls,
         }
     }
 
-    pub fn from_iter(ids: impl IntoIterator<Item = GroupId>) -> Self {
-        let mut c = Self::new();
-        for id in ids {
-            c.add(id);
-        }
-        c
-    }
-
-    /// Add new channel controls, wired to the specified fixture group.
-    pub fn add(&mut self, group: GroupId) -> ChannelId {
-        let id = ChannelId(self.channel_index.len());
-        self.channel_index.push(group);
-        self.fixture_channel_index.insert(group, id);
-        // If this is the first channel we're configuring, set it as selected.
-        if self.current_channel.is_none() {
-            self.current_channel = Some(id);
-        }
-        id
-    }
-
-    /// Return the number of channels.
-    pub fn channel_count(&self) -> usize {
-        self.channel_index.len()
-    }
-
-    /// Iterate over valid channel IDs.
-    pub fn channel_ids(&self) -> impl Iterator<Item = ChannelId> + '_ {
-        self.channel_index
-            .iter()
-            .enumerate()
-            .map(|(i, _)| ChannelId(i))
-    }
-
-    /// Validate that a channel index refers to a channel that actually exists.
-    pub fn validate_channel(&self, channel: usize) -> Result<ChannelId> {
-        if channel < self.channel_index.len() {
-            Ok(ChannelId(channel))
-        } else {
-            bail!(
-                "channel selector {channel} out of range, only {} channels are configured",
-                self.channel_index.len()
-            );
-        }
-    }
-
-    /// Look up a channel ID by the fixture group's stable identity.
-    pub fn channel_for_id(&self, group: GroupId) -> Option<ChannelId> {
-        self.fixture_channel_index.get(&group).cloned()
-    }
-
-    /// Look up a channel ID by the fixture group's display name. For OSC entry
-    /// points where the address provides a name string.
-    pub fn channel_for_name(&self, name: &str, patch: &Patch) -> Option<ChannelId> {
-        let group = patch.get(name).ok()?;
-        self.channel_for_id(group.id())
-    }
-
-    /// Iterate over all of the labels for each channel.
-    pub fn channel_labels<'a>(&'a self, patch: &'a Patch) -> impl Iterator<Item = String> + 'a {
-        self.channel_index
-            .iter()
-            .filter_map(|id| match patch.get_by_id(*id) {
-                Some(f) => Some(f),
-                None => {
-                    error!("Patch inconsistency generating channel labels: missing group {id}");
-                    None
-                }
-            })
-            .map(move |g| g.qualified_name().to_string())
-    }
-
-    /// Get a fixture group by channel ID.
-    pub fn group_by_channel<'a>(
-        &self,
-        patch: &'a Patch,
-        channel: ChannelId,
-    ) -> Result<&'a FixtureGroup> {
-        let Some(group_id) = self.channel_index.get(channel.0) else {
-            bail!("tried to get out-of-range channel {channel}");
-        };
-        patch
-            .get_by_id(*group_id)
-            .ok_or_else(|| anyhow!("channel {channel}: group {group_id} not in patch"))
-    }
-
-    /// Get a fixture group by channel ID, mutably.
-    pub fn group_by_channel_mut<'a>(
-        &self,
-        patch: &'a mut Patch,
-        channel: ChannelId,
-    ) -> Result<&'a mut FixtureGroup> {
-        let Some(group_id) = self.channel_index.get(channel.0).copied() else {
-            bail!("tried to get out-of-range channel {channel}");
-        };
-        patch
-            .get_mut_by_id(group_id)
-            .ok_or_else(|| anyhow!("channel {channel}: group {group_id} not in patch"))
-    }
-
     pub fn current_channel(&self) -> Option<ChannelId> {
         self.current_channel
+    }
+
+    /// Reconcile selection state against a freshly-(re)built patch. If the
+    /// currently-selected channel is no longer in range, fall back to the
+    /// first channel (or `None` if the patch has none).
+    pub fn reconcile_to_patch(&mut self, patch: &Patch) {
+        self.current_channel = match self.current_channel {
+            Some(ch) if ch.inner() < patch.channel_count() => Some(ch),
+            _ if patch.channel_count() > 0 => Some(ChannelId::new(0)),
+            _ => None,
+        };
     }
 
     /// Emit all current channel state.
@@ -179,27 +101,27 @@ impl Channels {
             Self::emit_osc_state_change(sc, &scoped_emitter);
         }
         Self::emit_osc_state_change(
-            StateChange::ChannelLabels(self.channel_labels(patch).collect()),
+            StateChange::ChannelLabels(patch.channel_labels().collect()),
             &scoped_emitter,
         );
         if selected_fixture_only {
             if let Some(channel_id) = self.current_channel {
-                match self.group_by_channel(patch, channel_id) {
-                    Ok(f) => f.emit_state(ChannelStateEmitter {
+                match patch.group_in_channel(channel_id) {
+                    Some(f) => f.emit_state(ChannelStateEmitter {
                         channel_id: Some(channel_id),
                         emitter,
                     }),
-                    Err(err) => error!("Failed to emit channel {channel_id} state: {err}."),
+                    None => error!("Failed to emit state for missing channel {channel_id}"),
                 }
             }
         } else {
-            for channel_id in self.channel_ids() {
-                match self.group_by_channel(patch, channel_id) {
-                    Ok(f) => f.emit_state(ChannelStateEmitter {
+            for channel_id in patch.channel_ids() {
+                match patch.group_in_channel(channel_id) {
+                    Some(f) => f.emit_state(ChannelStateEmitter {
                         channel_id: Some(channel_id),
                         emitter,
                     }),
-                    Err(err) => error!("Failed to emit channel {channel_id} state: {err}."),
+                    None => error!("Failed to emit state for missing channel {channel_id}"),
                 }
             }
         }
@@ -229,8 +151,7 @@ impl Channels {
     ) -> anyhow::Result<()> {
         match ctl {
             ControlMessage::SelectChannel(g) => {
-                // Validate the channel.
-                let channel = self.validate_channel(*g)?;
+                let channel = patch.validate_channel(*g)?;
                 if self.current_channel == Some(channel) {
                     // Channel is not changed, ignore.
                     return Ok(());
@@ -238,9 +159,12 @@ impl Channels {
                 self.current_channel = Some(channel);
                 self.emit_state(true, patch, emitter);
                 // FIXME this is so goddamn inside out, I hate it.
+                let group = patch
+                    .group_in_channel(channel)
+                    .ok_or_else(|| anyhow!("no group in channel {channel}"))?;
                 animation_ui.emit_state(
                     channel,
-                    self.group_by_channel(patch, channel)?,
+                    group,
                     &ScopedControlEmitter {
                         entity: crate::osc::animation::GROUP,
                         emitter,
@@ -249,7 +173,7 @@ impl Channels {
             }
             ControlMessage::Control { channel_id, msg } => {
                 let channel_id = if let Some(id) = channel_id {
-                    self.validate_channel(*id)?
+                    patch.validate_channel(*id)?
                 } else {
                     self.current_channel.ok_or_else(|| {
                         anyhow!(
@@ -257,8 +181,9 @@ impl Channels {
                         )
                     })?
                 };
-                let handled = self
-                    .group_by_channel_mut(patch, channel_id)?
+                let handled = patch
+                    .group_in_channel_mut(channel_id)
+                    .ok_or_else(|| anyhow!("no group in channel {channel_id}"))?
                     .control_from_channel(
                         msg,
                         ChannelStateEmitter {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use crate::{
     animation::AnimationUIState,
     control::EmitControlMessage,
-    fixture::{Patch, patch::patch_inconsistency},
+    fixture::Patch,
     osc::{EmitOscMessage, GroupControlMap, OscControlMessage, ScopedControlEmitter},
 };
 
@@ -104,39 +104,20 @@ impl Channels {
         );
         if selected_fixture_only {
             if let Some(channel_id) = self.current_channel {
-                match patch.group_in_channel(channel_id) {
-                    Some(f) => f.emit_state(ChannelStateEmitter {
+                match patch.channel_group(channel_id) {
+                    Ok(f) => f.emit_state(ChannelStateEmitter {
                         channel_id: Some(channel_id),
                         emitter,
                     }),
-                    None => error!(
-                        "{}",
-                        patch_inconsistency(
-                            "PI-008",
-                            format!(
-                                "emit_state: selected channel {channel_id} has no group in patch"
-                            ),
-                        )
-                    ),
+                    Err(e) => error!("{e:#}"),
                 }
             }
         } else {
-            for channel_id in patch.channel_ids() {
-                match patch.group_in_channel(channel_id) {
-                    Some(f) => f.emit_state(ChannelStateEmitter {
-                        channel_id: Some(channel_id),
-                        emitter,
-                    }),
-                    None => error!(
-                        "{}",
-                        patch_inconsistency(
-                            "PI-009",
-                            format!(
-                                "emit_state: channel {channel_id} from channel_ids() has no group in patch"
-                            ),
-                        )
-                    ),
-                }
+            for (channel_id, group) in patch.channels_with_ids() {
+                group.emit_state(ChannelStateEmitter {
+                    channel_id: Some(channel_id),
+                    emitter,
+                });
             }
         }
     }
@@ -165,22 +146,13 @@ impl Channels {
     ) -> anyhow::Result<()> {
         match ctl {
             ControlMessage::SelectChannel(g) => {
-                let channel = patch.validate_channel(*g)?;
+                let (channel, group) = patch.channel(*g)?;
                 if self.current_channel == Some(channel) {
                     // Channel is not changed, ignore.
                     return Ok(());
                 }
                 self.current_channel = Some(channel);
                 self.emit_state(true, patch, emitter);
-
-                let group = patch.group_in_channel(channel).ok_or_else(|| {
-                    patch_inconsistency(
-                        "PI-002",
-                        format!(
-                            "SelectChannel: channel {channel} validated but has no group in patch"
-                        ),
-                    )
-                })?;
                 // FIXME this is so goddamn inside out, I hate it.
                 animation_ui.emit_state(
                     channel,
@@ -192,32 +164,23 @@ impl Channels {
                 );
             }
             ControlMessage::Control { channel_id, msg } => {
-                let channel_id = if let Some(id) = channel_id {
-                    patch.validate_channel(*id)?
+                let (channel_id, group) = if let Some(id) = channel_id {
+                    patch.channel_mut(*id)?
                 } else {
-                    self.current_channel.ok_or_else(|| {
+                    let selected = self.current_channel.ok_or_else(|| {
                         anyhow!(
                             "no channel ID provided or selected for channel control message {msg:?}"
                         )
-                    })?
+                    })?;
+                    (selected, patch.channel_group_mut(selected)?)
                 };
-                let handled = patch
-                    .group_in_channel_mut(channel_id)
-                    .ok_or_else(|| {
-                        patch_inconsistency(
-                            "PI-003",
-                            format!(
-                                "channel control: channel {channel_id} validated but has no group in patch"
-                            ),
-                        )
-                    })?
-                    .control_from_channel(
-                        msg,
-                        ChannelStateEmitter {
-                            channel_id: Some(channel_id),
-                            emitter,
-                        },
-                    )?;
+                let handled = group.control_from_channel(
+                    msg,
+                    ChannelStateEmitter {
+                        channel_id: Some(channel_id),
+                        emitter,
+                    },
+                )?;
                 if !handled {
                     debug!(
                         "Fixture in channel {channel_id} did not handle channel control message {msg:?}."

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use crate::{
     animation::AnimationUIState,
     control::EmitControlMessage,
-    fixture::Patch,
+    fixture::{Patch, patch::patch_inconsistency},
     osc::{EmitOscMessage, GroupControlMap, OscControlMessage, ScopedControlEmitter},
 };
 
@@ -47,9 +47,7 @@ impl Display for ChannelId {
     }
 }
 
-/// OSC dispatch and selection state for channels. Channel membership and
-/// channel→group lookups live on `Patch`; this struct just remembers which
-/// channel is currently selected and routes incoming channel control messages.
+/// OSC dispatch and selection state for channels.
 pub struct Channels {
     /// The channel ID that is currently selected.
     current_channel: Option<ChannelId>,
@@ -111,7 +109,15 @@ impl Channels {
                         channel_id: Some(channel_id),
                         emitter,
                     }),
-                    None => error!("Failed to emit state for missing channel {channel_id}"),
+                    None => error!(
+                        "{}",
+                        patch_inconsistency(
+                            "PI-008",
+                            format!(
+                                "emit_state: selected channel {channel_id} has no group in patch"
+                            ),
+                        )
+                    ),
                 }
             }
         } else {
@@ -121,7 +127,15 @@ impl Channels {
                         channel_id: Some(channel_id),
                         emitter,
                     }),
-                    None => error!("Failed to emit state for missing channel {channel_id}"),
+                    None => error!(
+                        "{}",
+                        patch_inconsistency(
+                            "PI-009",
+                            format!(
+                                "emit_state: channel {channel_id} from channel_ids() has no group in patch"
+                            ),
+                        )
+                    ),
                 }
             }
         }
@@ -158,10 +172,16 @@ impl Channels {
                 }
                 self.current_channel = Some(channel);
                 self.emit_state(true, patch, emitter);
+
+                let group = patch.group_in_channel(channel).ok_or_else(|| {
+                    patch_inconsistency(
+                        "PI-002",
+                        format!(
+                            "SelectChannel: channel {channel} validated but has no group in patch"
+                        ),
+                    )
+                })?;
                 // FIXME this is so goddamn inside out, I hate it.
-                let group = patch
-                    .group_in_channel(channel)
-                    .ok_or_else(|| anyhow!("no group in channel {channel}"))?;
                 animation_ui.emit_state(
                     channel,
                     group,
@@ -183,7 +203,14 @@ impl Channels {
                 };
                 let handled = patch
                     .group_in_channel_mut(channel_id)
-                    .ok_or_else(|| anyhow!("no group in channel {channel_id}"))?
+                    .ok_or_else(|| {
+                        patch_inconsistency(
+                            "PI-003",
+                            format!(
+                                "channel control: channel {channel_id} validated but has no group in patch"
+                            ),
+                        )
+                    })?
                     .control_from_channel(
                         msg,
                         ChannelStateEmitter {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,35 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_yaml::{Mapping, Value};
 use std::{borrow::Borrow, fmt::Display, ops::Deref};
+use uuid::Uuid;
+
+/// Stable, opaque identifier for a fixture group.
+///
+/// Minted when the group is first created in the patch editor and preserved
+/// across renames, repatches, and (eventually) restarts. The operator never
+/// sees this; it exists purely so the controller can answer "is this the same
+/// group it was before?" when the display name has changed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GroupId(Uuid);
+
+impl GroupId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for GroupId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for GroupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -16,6 +45,12 @@ pub enum DmxAddrConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FixtureGroupConfig {
+    /// Stable opaque identifier. Minted on first load (or first creation in the
+    /// patch editor) and preserved across renames so the controller can carry
+    /// per-group state forward through repatches.
+    #[serde(default)]
+    pub id: GroupId,
+
     /// The type of fixture to patch.
     pub fixture: String,
 
@@ -246,5 +281,36 @@ mod test {
     fn options_remove_missing_key_is_noop() {
         let mut opts = Options::default();
         opts.remove("nonexistent"); // should not panic
+    }
+
+    /// Existing patch YAML on disk does not carry a `id` field. Loading must
+    /// silently mint a UUID per group; round-tripping that loaded config back
+    /// to YAML and reloading it must preserve the freshly-minted id so identity
+    /// is stable on the next launch.
+    #[test]
+    fn fixture_group_config_serde_defaults_id_and_round_trips() {
+        let yaml = "
+- fixture: Color
+  control_color_space: Hsluv
+  patches:
+    - addr: 1
+- fixture: Dimmer
+  group: TestGroup
+  patches:
+    - addr: 1
+      universe: 1
+";
+        let loaded: Vec<FixtureGroupConfig> =
+            serde_yaml::from_str(yaml).expect("legacy YAML without ids should still parse");
+        assert_eq!(loaded.len(), 2);
+
+        let id_color = loaded[0].id;
+        let id_dimmer = loaded[1].id;
+        assert_ne!(id_color, id_dimmer, "each group gets a distinct fresh id");
+
+        let round_tripped: Vec<FixtureGroupConfig> =
+            serde_yaml::from_str(&serde_yaml::to_string(&loaded).unwrap()).unwrap();
+        assert_eq!(round_tripped[0].id, id_color);
+        assert_eq!(round_tripped[1].id, id_dimmer);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,12 +22,6 @@ impl GroupId {
     }
 }
 
-impl Default for GroupId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Display for GroupId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.0, f)
@@ -48,7 +42,7 @@ pub struct FixtureGroupConfig {
     /// Stable opaque identifier. Minted on first load (or first creation in the
     /// patch editor) and preserved across renames so the controller can carry
     /// per-group state forward through repatches.
-    #[serde(default)]
+    #[serde(default = "GroupId::new")]
     pub id: GroupId,
 
     /// The type of fixture to patch.

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 /// Stable, opaque identifier for a fixture group.
 ///
 /// Minted when the group is first created in the patch editor and preserved
-/// across renames, repatches, and (eventually) restarts. The operator never
+/// across renames, repatches, and restarts. The operator never
 /// sees this; it exists purely so the controller can answer "is this the same
 /// group it was before?" when the group name has changed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -19,12 +19,6 @@ pub struct GroupId(Uuid);
 impl GroupId {
     pub fn new() -> Self {
         Self(Uuid::new_v4())
-    }
-}
-
-impl Display for GroupId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, f)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 /// Minted when the group is first created in the patch editor and preserved
 /// across renames, repatches, and (eventually) restarts. The operator never
 /// sees this; it exists purely so the controller can answer "is this the same
-/// group it was before?" when the display name has changed.
+/// group it was before?" when the group name has changed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct GroupId(Uuid);
@@ -51,7 +51,7 @@ pub struct FixtureGroupConfig {
     /// For fixtures that we may want to separately control multiple instances,
     /// provide a group name.
     #[serde(default)]
-    pub group: Option<FixtureGroupKey>,
+    pub group: Option<GroupName>,
 
     /// If true, assign to a channel. Defaults to true.
     #[serde(default = "_true")]
@@ -70,9 +70,9 @@ pub struct FixtureGroupConfig {
 }
 
 impl FixtureGroupConfig {
-    /// Get the key for this group, either the name of the fixture, or the
-    /// group name if one is provided.
-    pub fn key(&self) -> &str {
+    /// Get the name of this group: the explicit group name if provided,
+    /// otherwise the fixture type name.
+    pub fn name(&self) -> &str {
         self.group.as_deref().unwrap_or(&self.fixture)
     }
 }
@@ -202,23 +202,25 @@ fn string_value(v: &Value) -> String {
     }
 }
 
-/// Uniquely identify a specific fixture group.
+/// Human-readable name for a fixture group. Used in OSC addresses and patch
+/// YAML; serves as a unique lookup key into the patch alongside the stable
+/// [`GroupId`]. May be changed by the operator (renames are non-destructive).
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
-pub struct FixtureGroupKey(pub String);
+pub struct GroupName(pub String);
 
-impl Display for FixtureGroupKey {
+impl Display for GroupName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
-impl Borrow<str> for FixtureGroupKey {
+impl Borrow<str> for GroupName {
     fn borrow(&self) -> &str {
         &self.0
     }
 }
 
-impl Deref for FixtureGroupKey {
+impl Deref for GroupName {
     type Target = str;
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/config_gui/osc_panel.rs
+++ b/src/config_gui/osc_panel.rs
@@ -98,7 +98,7 @@ impl OscPanel<'_> {
             .groups
             .iter()
             .map(|cfg| GroupEntry {
-                group_name: cfg.key(),
+                group_name: cfg.name(),
                 fixture_type: &cfg.fixture,
             })
             .collect();

--- a/src/config_gui/patch_panel/address_map.rs
+++ b/src/config_gui/patch_panel/address_map.rs
@@ -19,7 +19,7 @@ impl AddressMap {
     pub fn from_working_copy(wc: &PatchWorkingCopy) -> Self {
         let mut map = BTreeMap::new();
         for group in &wc.groups {
-            let name = group.config.key().to_string();
+            let name = group.config.name().to_string();
             for (pi, block) in group.config.patches.iter().enumerate() {
                 let (start, count) = block.start_count();
                 let Some(start_addr) = start else { continue };

--- a/src/config_gui/patch_panel/mod.rs
+++ b/src/config_gui/patch_panel/mod.rs
@@ -4,7 +4,7 @@ mod working_copy;
 
 use eframe::egui;
 
-use crate::config::{DmxAddrConfig, FixtureGroupConfig, FixtureGroupKey, GroupId, PatchBlock};
+use crate::config::{DmxAddrConfig, FixtureGroupConfig, GroupId, GroupName, PatchBlock};
 use crate::control::MetaCommand;
 use crate::dmx::DmxAddr;
 use crate::fixture::patch::{PatchOption, Patcher};
@@ -264,7 +264,7 @@ impl PatchPanel<'_> {
                 .and_then(|wc| {
                     wc.groups
                         .get(group_idx)
-                        .map(|g| (g.config.key().to_string(), g.config.patches.len()))
+                        .map(|g| (g.config.name().to_string(), g.config.patches.len()))
                 })
                 .unwrap_or_default();
 
@@ -391,7 +391,7 @@ impl PatchPanel<'_> {
                                         None => "-".to_string(),
                                     };
                                     ui.label(&ch_text);
-                                    ui.label(group.config.key());
+                                    ui.label(group.config.name());
                                     ui.label(&group.config.fixture);
                                     ui.label(format!("{}", group.config.patches.len()));
 
@@ -499,7 +499,7 @@ impl PatchPanel<'_> {
                     cfg.group = if name.is_empty() {
                         None
                     } else {
-                        Some(FixtureGroupKey(name))
+                        Some(GroupName(name))
                     };
                 }
             });
@@ -814,7 +814,7 @@ impl PatchPanel<'_> {
         let group_name = if form.group_name.is_empty() {
             None
         } else {
-            Some(FixtureGroupKey(form.group_name.clone()))
+            Some(GroupName(form.group_name.clone()))
         };
 
         let config = FixtureGroupConfig {
@@ -1140,7 +1140,7 @@ mod test {
         FixtureGroupConfig {
             id: GroupId::new(),
             fixture: "Simple".to_string(),
-            group: name.map(|n| FixtureGroupKey(n.to_string())),
+            group: name.map(|n| GroupName(n.to_string())),
             channel: true,
             color_organ: false,
             patches: addrs.iter().map(|&a| simple_block(a)).collect(),
@@ -1165,7 +1165,7 @@ mod test {
         FixtureGroupConfig {
             id: GroupId::new(),
             fixture: "PatchOpts".to_string(),
-            group: name.map(|n| FixtureGroupKey(n.to_string())),
+            group: name.map(|n| GroupName(n.to_string())),
             channel: true,
             color_organ: false,
             patches: blocks,
@@ -1182,7 +1182,7 @@ mod test {
         FixtureGroupConfig {
             id: GroupId::new(),
             fixture: "GroupOpts".to_string(),
-            group: name.map(|n| FixtureGroupKey(n.to_string())),
+            group: name.map(|n| GroupName(n.to_string())),
             channel: true,
             color_organ: false,
             patches: vec![simple_block(100)],
@@ -1262,7 +1262,7 @@ mod test {
         wc.groups
             .push(PatchWorkingCopy::resolve_group(&config, &patchers));
         assert_eq!(wc.groups.len(), 1);
-        assert_eq!(wc.groups[0].config.key(), "NewGroup");
+        assert_eq!(wc.groups[0].config.name(), "NewGroup");
         assert_eq!(wc.groups[0].channel_counts, vec![1]);
     }
 
@@ -1273,7 +1273,7 @@ mod test {
         assert_eq!(wc.groups.len(), 2);
         wc.groups.remove(0);
         assert_eq!(wc.groups.len(), 1);
-        assert_eq!(wc.groups[0].config.key(), "BackSimple");
+        assert_eq!(wc.groups[0].config.name(), "BackSimple");
     }
 
     #[test]
@@ -1326,7 +1326,7 @@ mod test {
         let configs = wc.configs();
         assert_eq!(configs.len(), 2);
         assert_eq!(configs[0].fixture, "Simple");
-        assert_eq!(configs[1].key(), "BackSimple");
+        assert_eq!(configs[1].name(), "BackSimple");
     }
 
     #[test]
@@ -1352,11 +1352,11 @@ mod test {
     fn swap_groups_reorders() {
         let mut wc =
             PatchWorkingCopy::from_snapshot(&test_snapshot_with_groups(), &test_patchers());
-        assert_eq!(wc.groups[0].config.key(), "Simple");
-        assert_eq!(wc.groups[1].config.key(), "BackSimple");
+        assert_eq!(wc.groups[0].config.name(), "Simple");
+        assert_eq!(wc.groups[1].config.name(), "BackSimple");
         wc.groups.swap(0, 1);
-        assert_eq!(wc.groups[0].config.key(), "BackSimple");
-        assert_eq!(wc.groups[1].config.key(), "Simple");
+        assert_eq!(wc.groups[0].config.name(), "BackSimple");
+        assert_eq!(wc.groups[1].config.name(), "Simple");
     }
 
     fn ua(universe: usize, address: usize) -> UniverseAddress {
@@ -1394,7 +1394,7 @@ mod test {
                 FixtureGroupConfig {
                     id: GroupId::new(),
                     fixture: "Simple".to_string(),
-                    group: Some(FixtureGroupKey("B".to_string())),
+                    group: Some(GroupName("B".to_string())),
                     channel: true,
                     color_organ: false,
                     patches: vec![PatchBlock {
@@ -1709,7 +1709,7 @@ mod test {
         FixtureGroupConfig {
             id: GroupId::new(),
             fixture: "NonDmx".to_string(),
-            group: name.map(|n| FixtureGroupKey(n.to_string())),
+            group: name.map(|n| GroupName(n.to_string())),
             channel: true,
             color_organ: false,
             patches: vec![],

--- a/src/config_gui/patch_panel/mod.rs
+++ b/src/config_gui/patch_panel/mod.rs
@@ -4,7 +4,7 @@ mod working_copy;
 
 use eframe::egui;
 
-use crate::config::{DmxAddrConfig, FixtureGroupConfig, FixtureGroupKey, PatchBlock};
+use crate::config::{DmxAddrConfig, FixtureGroupConfig, FixtureGroupKey, GroupId, PatchBlock};
 use crate::control::MetaCommand;
 use crate::dmx::DmxAddr;
 use crate::fixture::patch::{PatchOption, Patcher};
@@ -818,6 +818,7 @@ impl PatchPanel<'_> {
         };
 
         let config = FixtureGroupConfig {
+            id: GroupId::new(),
             fixture: patcher.name.0.to_string(),
             group: group_name,
             channel: form.channel,
@@ -1021,7 +1022,7 @@ mod test {
     fn mock_simple_patcher() -> Patcher {
         Patcher {
             name: FixtureType("Simple"),
-            create_group: |_, _| unimplemented!(),
+            create_group: |_, _, _| unimplemented!(),
             group_options: || vec![],
             create_patch: |_, _| {
                 Ok(PatchConfig {
@@ -1037,7 +1038,7 @@ mod test {
     fn mock_group_opts_patcher() -> Patcher {
         Patcher {
             name: FixtureType("GroupOpts"),
-            create_group: |_, _| unimplemented!(),
+            create_group: |_, _, _| unimplemented!(),
             group_options: || {
                 vec![
                     ("paired".into(), PatchOption::Bool),
@@ -1068,7 +1069,7 @@ mod test {
     fn mock_patch_opts_patcher() -> Patcher {
         Patcher {
             name: FixtureType("PatchOpts"),
-            create_group: |_, _| unimplemented!(),
+            create_group: |_, _, _| unimplemented!(),
             group_options: || vec![],
             create_patch: |_, opts| {
                 let ch = match opts.get_string("variant").as_deref() {
@@ -1097,7 +1098,7 @@ mod test {
     fn mock_non_dmx_patcher() -> Patcher {
         Patcher {
             name: FixtureType("NonDmx"),
-            create_group: |_, _| unimplemented!(),
+            create_group: |_, _, _| unimplemented!(),
             group_options: || vec![],
             create_patch: |_, _| {
                 Ok(PatchConfig {
@@ -1137,6 +1138,7 @@ mod test {
 
     fn simple_group(name: Option<&str>, addrs: &[usize]) -> FixtureGroupConfig {
         FixtureGroupConfig {
+            id: GroupId::new(),
             fixture: "Simple".to_string(),
             group: name.map(|n| FixtureGroupKey(n.to_string())),
             channel: true,
@@ -1161,6 +1163,7 @@ mod test {
 
     fn patch_opts_group(name: Option<&str>, blocks: Vec<PatchBlock>) -> FixtureGroupConfig {
         FixtureGroupConfig {
+            id: GroupId::new(),
             fixture: "PatchOpts".to_string(),
             group: name.map(|n| FixtureGroupKey(n.to_string())),
             channel: true,
@@ -1177,6 +1180,7 @@ mod test {
         options.set_string("mode", "Fast");
         options.set_string("endpoint", "http://10.0.0.1:8080");
         FixtureGroupConfig {
+            id: GroupId::new(),
             fixture: "GroupOpts".to_string(),
             group: name.map(|n| FixtureGroupKey(n.to_string())),
             channel: true,
@@ -1237,6 +1241,7 @@ mod test {
     fn working_copy_unknown_fixture_gets_zero_channels() {
         let snapshot = PatchSnapshot {
             groups: vec![FixtureGroupConfig {
+                id: GroupId::new(),
                 fixture: "NonexistentFixture".to_string(),
                 group: None,
                 channel: true,
@@ -1387,6 +1392,7 @@ mod test {
             groups: vec![
                 simple_group(Some("A"), &[1]),
                 FixtureGroupConfig {
+                    id: GroupId::new(),
                     fixture: "Simple".to_string(),
                     group: Some(FixtureGroupKey("B".to_string())),
                     channel: true,
@@ -1701,6 +1707,7 @@ mod test {
 
     fn non_dmx_group(name: Option<&str>) -> FixtureGroupConfig {
         FixtureGroupConfig {
+            id: GroupId::new(),
             fixture: "NonDmx".to_string(),
             group: name.map(|n| FixtureGroupKey(n.to_string())),
             channel: true,

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -80,7 +80,7 @@ impl FixtureGroup {
         }
     }
 
-    /// Stable identity for this group. Survives renames across repatch.
+    /// Universally-stable identity for this group.
     pub fn id(&self) -> GroupId {
         self.id
     }
@@ -244,9 +244,16 @@ impl FixtureGroup {
             let phase_offset = phase_offset_per_fixture * i as f64;
             let Some(dmx_univ) = dmx.get_mut(cfg.universe) else {
                 error!(
-                    "Universe index {} for patch {i} of {} is out of range.",
-                    cfg.universe,
-                    self.qualified_name(),
+                    "{}",
+                    crate::fixture::patch::patch_inconsistency(
+                        "PI-010",
+                        format!(
+                            "render: fixture {i} of {} requested universe {} but only {} are available",
+                            self.qualified_name(),
+                            cfg.universe,
+                            dmx.len(),
+                        ),
+                    )
                 );
                 continue;
             };

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -16,8 +16,8 @@ use super::fixture::{Fixture, FixtureType, RenderMode};
 use super::prelude::ChannelStateEmitter;
 use crate::channel::ChannelControlMessage;
 use crate::color::Hsluv;
-use crate::config::FixtureGroupKey;
 use crate::config::GroupId;
+use crate::config::GroupName;
 use crate::config::Options;
 use crate::dmx::DmxUniverse;
 use crate::fixture::FixtureGroupControls;
@@ -34,9 +34,9 @@ pub struct FixtureGroup {
     id: GroupId,
     /// The fixture type of this group.
     fixture_type: FixtureType,
-    /// The display name of this group. Used in OSC addresses and patch YAML.
-    /// May change across repatches; identity is `id`, not this.
-    key: FixtureGroupKey,
+    /// Human-readable name for this group. Used in OSC addresses and patch
+    /// YAML. May change across repatches; stable identity is `id`, not this.
+    name: GroupName,
     /// The configurations for the fixtures in the group.
     fixture_configs: Vec<GroupFixtureConfig>,
     /// A color organ for controlling the group.
@@ -63,7 +63,7 @@ impl FixtureGroup {
     pub fn empty(
         id: GroupId,
         fixture_type: FixtureType,
-        key: FixtureGroupKey,
+        name: GroupName,
         fixture: Box<dyn Fixture>,
         strobe_response: Option<StrobeResponse>,
         options: Options,
@@ -73,7 +73,7 @@ impl FixtureGroup {
             flash_state: strobe_response.map(FlashState::new),
             id,
             fixture_type,
-            key,
+            name,
             fixture_configs: vec![],
             color_organ: None,
             fixture,
@@ -124,12 +124,13 @@ impl FixtureGroup {
 
     /// Return a struct that can write the qualified name of this group.
     ///
-    /// This will be just the fixture type name if the key is identical.
-    /// Otherwise, it will be the key followed by the fixture type in parentheses.
+    /// This will be just the fixture type name if the group name is identical.
+    /// Otherwise, it will be the group name followed by the fixture type in
+    /// parentheses.
     pub fn qualified_name(&self) -> FixtureGroupQualifiedNameFormatter<'_> {
         FixtureGroupQualifiedNameFormatter {
             fixture_type: self.fixture_type,
-            key: &self.key.0,
+            name: &self.name.0,
         }
     }
 
@@ -169,7 +170,7 @@ impl FixtureGroup {
             self.strobe_enabled,
         ));
         self.fixture
-            .emit_state(&FixtureStateEmitter::new(&self.key, emitter));
+            .emit_state(&FixtureStateEmitter::new(&self.name, emitter));
     }
 
     /// Process the provided control message.
@@ -180,7 +181,7 @@ impl FixtureGroup {
     ) -> anyhow::Result<()> {
         let handled = self
             .fixture
-            .control(msg, &FixtureStateEmitter::new(&self.key, emitter))
+            .control(msg, &FixtureStateEmitter::new(&self.name, emitter))
             .with_context(|| self.qualified_name().to_string())?;
         ensure!(
             handled,
@@ -196,7 +197,7 @@ impl FixtureGroup {
         msg: &ChannelControlMessage,
         channel_emitter: ChannelStateEmitter,
     ) -> anyhow::Result<bool> {
-        let emitter = &FixtureStateEmitter::new(&self.key, channel_emitter);
+        let emitter = &FixtureStateEmitter::new(&self.name, channel_emitter);
         if matches!(msg, ChannelControlMessage::ToggleStrobe) {
             // If the fixture can't strobe, ignore the control.
             if self.flash_state.is_none() {
@@ -301,15 +302,15 @@ pub struct GroupFixtureConfig {
 /// Format the qualified name of a fixture group without allocating.
 pub struct FixtureGroupQualifiedNameFormatter<'a> {
     fixture_type: FixtureType,
-    key: &'a str,
+    name: &'a str,
 }
 
 impl<'a> Display for FixtureGroupQualifiedNameFormatter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.key == self.fixture_type.0 {
+        if self.name == self.fixture_type.0 {
             f.write_str(&self.fixture_type)
         } else {
-            write!(f, "{}({})", self.key, self.fixture_type)
+            write!(f, "{}({})", self.name, self.fixture_type)
         }
     }
 }

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -246,7 +246,7 @@ impl FixtureGroup {
                 error!(
                     "{}",
                     crate::fixture::patch::patch_inconsistency(
-                        "PI-010",
+                        "PI-004",
                         format!(
                             "render: fixture {i} of {} requested universe {} but only {} are available",
                             self.qualified_name(),

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -29,13 +29,12 @@ use crate::strobe::FlashState;
 use crate::strobe::StrobeResponse;
 
 pub struct FixtureGroup {
-    /// Stable identity for this group, used to carry state across repatch
-    /// even when the operator renames the group.
+    /// Stable UUID-based identity for this group.
     id: GroupId,
     /// The fixture type of this group.
     fixture_type: FixtureType,
-    /// Human-readable name for this group. Used in OSC addresses and patch
-    /// YAML. May change across repatches; stable identity is `id`, not this.
+    /// Human-readable name for this group. Used in OSC addresses.
+    /// May change across repatches; stable identity is `id`, not this.
     name: GroupName,
     /// The configurations for the fixtures in the group.
     fixture_configs: Vec<GroupFixtureConfig>,

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -86,12 +86,6 @@ impl FixtureGroup {
         self.id
     }
 
-    /// Display name for this group. Used in OSC addresses and patch YAML.
-    /// Convenient `&str` form for string comparisons and address building.
-    pub fn key_str(&self) -> &str {
-        &self.key.0
-    }
-
     /// Reconfigure this group using the state from another group, if compatible.
     ///
     /// Return true if we performed reconfiguration.

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -17,6 +17,7 @@ use super::prelude::ChannelStateEmitter;
 use crate::channel::ChannelControlMessage;
 use crate::color::Hsluv;
 use crate::config::FixtureGroupKey;
+use crate::config::GroupId;
 use crate::config::Options;
 use crate::dmx::DmxUniverse;
 use crate::fixture::FixtureGroupControls;
@@ -28,9 +29,13 @@ use crate::strobe::FlashState;
 use crate::strobe::StrobeResponse;
 
 pub struct FixtureGroup {
+    /// Stable identity for this group, used to carry state across repatch
+    /// even when the operator renames the group.
+    id: GroupId,
     /// The fixture type of this group.
     fixture_type: FixtureType,
-    /// The unique identifier of this group. Often identical to the fixture type.
+    /// The display name of this group. Used in OSC addresses and patch YAML.
+    /// May change across repatches; identity is `id`, not this.
     key: FixtureGroupKey,
     /// The configurations for the fixtures in the group.
     fixture_configs: Vec<GroupFixtureConfig>,
@@ -56,6 +61,7 @@ pub struct FixtureGroup {
 impl FixtureGroup {
     /// Create empty fixture group from an initialized fixture model.
     pub fn empty(
+        id: GroupId,
         fixture_type: FixtureType,
         key: FixtureGroupKey,
         fixture: Box<dyn Fixture>,
@@ -65,6 +71,7 @@ impl FixtureGroup {
         Self {
             strobe_enabled: false,
             flash_state: strobe_response.map(FlashState::new),
+            id,
             fixture_type,
             key,
             fixture_configs: vec![],
@@ -72,6 +79,17 @@ impl FixtureGroup {
             fixture,
             options,
         }
+    }
+
+    /// Stable identity for this group. Survives renames across repatch.
+    pub fn id(&self) -> GroupId {
+        self.id
+    }
+
+    /// Display name for this group. Used in OSC addresses and patch YAML.
+    /// Convenient `&str` form for string comparisons and address building.
+    pub fn key_str(&self) -> &str {
+        &self.key.0
     }
 
     /// Reconfigure this group using the state from another group, if compatible.

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -2,11 +2,12 @@
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use itertools::Itertools;
 use log::info;
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::fmt::Display;
 
 use super::fixture::FixtureType;
 use super::group::FixtureGroup;
-use crate::channel::ChannelId;
 use crate::config::{FixtureGroupConfig, GroupId, GroupName};
 use crate::dmx::UniverseIdx;
 use crate::fixture::group::GroupFixtureConfig;
@@ -277,7 +278,7 @@ impl Patch {
 
         let id = group.id();
         let location = if cfg.channel {
-            let channel_id = ChannelId::new(self.channels.len());
+            let channel_id = ChannelId(self.channels.len());
             self.channels.push(group);
             GroupLocation::Channel(channel_id)
         } else {
@@ -304,6 +305,11 @@ impl Patch {
     }
 
     // ---- Lookups ------------------------------------------------------------
+
+    /// Return the first channel ID, if we have at least one group with a channel.
+    pub fn first_channel(&self) -> Option<ChannelId> {
+        (self.channel_count() > 0).then_some(ChannelId(0))
+    }
 
     /// Look up a group by its name. Exercised by tests; production OSC
     /// dispatch goes through [`lookup_mut_by_name`] which also returns the
@@ -363,7 +369,7 @@ impl Patch {
                 self.channels.len()
             )
         })?;
-        Ok((ChannelId::new(raw_id), group))
+        Ok((ChannelId(raw_id), group))
     }
 
     /// Mutable counterpart to [`Patch::channel`].
@@ -372,7 +378,7 @@ impl Patch {
         let group = self.channels.get_mut(raw_id).ok_or_else(|| {
             anyhow!("channel selector {raw_id} out of range, only {len} channels are configured")
         })?;
-        Ok((ChannelId::new(raw_id), group))
+        Ok((ChannelId(raw_id), group))
     }
 
     /// Look up the group on a specific channel by trusted [`ChannelId`].
@@ -410,7 +416,7 @@ impl Patch {
         self.channels
             .iter()
             .enumerate()
-            .map(|(i, g)| (ChannelId::new(i), g))
+            .map(|(i, g)| (ChannelId(i), g))
     }
 
     /// Iterate over the channel labels, in channel order. Uses each group's
@@ -497,6 +503,28 @@ impl UsedAddrs {
         // TODO: destroy this or generalize it.
         let swarm = crate::fixture::swarmolon::affinity();
         swarm.contains(&f0) && swarm.contains(&f1)
+    }
+}
+
+/// The index of a channel within the patch's channel-bound groups.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize)]
+pub struct ChannelId(usize);
+
+impl ChannelId {
+    pub fn inner(&self) -> usize {
+        self.0
+    }
+}
+
+impl From<ChannelId> for usize {
+    fn from(value: ChannelId) -> Self {
+        value.0
+    }
+}
+
+impl Display for ChannelId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use super::fixture::FixtureType;
 use super::group::FixtureGroup;
 use crate::channel::ChannelId;
-use crate::config::{FixtureGroupConfig, FixtureGroupKey, GroupId};
+use crate::config::{FixtureGroupConfig, GroupId, GroupName};
 use crate::dmx::UniverseIdx;
 use crate::fixture::group::GroupFixtureConfig;
 
@@ -49,7 +49,7 @@ impl GroupLocation {
 /// Factory for fixture instances.
 ///
 /// Owns the fixture groups themselves and the indices used to look them up by
-/// display name, stable id, or channel position. Maintains a mapping of which
+/// group name, stable id, or channel position. Maintains a mapping of which
 /// DMX addresses are in use by which fixture, to prevent addressing collisions.
 ///
 /// Storage layout: groups physically live in either `channels` (in channel
@@ -67,7 +67,7 @@ pub struct Patch {
     non_channel: Vec<FixtureGroup>,
     /// O(1) lookup from stable id to physical location.
     by_id: HashMap<GroupId, GroupLocation>,
-    /// O(1) lookup from display name to physical location.
+    /// O(1) lookup from group name to physical location.
     by_name: HashMap<String, GroupLocation>,
     /// Which DMX addrs already have a fixture patched in them.
     used_addrs: UsedAddrs,
@@ -162,27 +162,27 @@ impl Patch {
     fn patch(&mut self, cfg: &FixtureGroupConfig) -> Result<()> {
         let patcher = self.patcher(&cfg.fixture)?;
 
-        if let Some(group_key) = &cfg.group {
+        if let Some(group_name) = &cfg.group {
             // If there's a patcher that matches this group name, fail.
             ensure!(
-                self.patcher(group_key).is_err(),
-                "the group key '{group_key}' cannot be used because it is also a fixture name"
+                self.patcher(group_name).is_err(),
+                "the group name '{group_name}' cannot be used because it is also a fixture name"
             );
         }
 
-        let group_key = FixtureGroupKey(cfg.key().to_string());
+        let group_name = GroupName(cfg.name().to_string());
 
         ensure!(
-            !self.by_name.contains_key(&group_key.0),
-            "duplicate group key '{group_key}'"
+            !self.by_name.contains_key(&group_name.0),
+            "duplicate group name '{group_name}'"
         );
         ensure!(
             !self.by_id.contains_key(&cfg.id),
-            "duplicate group id '{}' for group '{group_key}'",
+            "duplicate group id '{}' for group '{group_name}'",
             cfg.id
         );
 
-        let mut group = (patcher.create_group)(cfg.id, group_key.clone(), cfg.options.clone())?;
+        let mut group = (patcher.create_group)(cfg.id, group_name.clone(), cfg.options.clone())?;
 
         ensure!(!cfg.patches.is_empty(), "no patches specified");
 
@@ -270,7 +270,7 @@ impl Patch {
             GroupLocation::NonChannel(idx)
         };
         self.by_id.insert(id, location);
-        self.by_name.insert(group_key.0, location);
+        self.by_name.insert(group_name.0, location);
         Ok(())
     }
 
@@ -289,9 +289,9 @@ impl Patch {
 
     // ---- Lookups ------------------------------------------------------------
 
-    /// Look up a group by its display name (the OSC-facing name).
-    /// Exercised by tests; production OSC dispatch goes through
-    /// [`lookup_mut_by_name`] which also returns the channel id.
+    /// Look up a group by its name. Exercised by tests; production OSC
+    /// dispatch goes through [`lookup_mut_by_name`] which also returns the
+    /// channel id.
     #[allow(dead_code)]
     pub fn group_by_name(&self, name: &str) -> Option<&FixtureGroup> {
         match *self.by_name.get(name)? {
@@ -300,9 +300,9 @@ impl Patch {
         }
     }
 
-    /// Look up a group by its display name, also returning the channel id if
-    /// it's channel-bound. Hot path for OSC dispatch — single hash lookup
-    /// plus a direct Vec index.
+    /// Look up a group by its name, also returning the channel id if it's
+    /// channel-bound. Hot path for OSC dispatch — single hash lookup plus a
+    /// direct Vec index.
     pub fn lookup_mut_by_name(
         &mut self,
         name: &str,
@@ -655,7 +655,7 @@ mod test {
     }
 
     #[test]
-    fn test_dupe_group_key() {
+    fn test_dupe_group_name() {
         // Can't specify the same fixture twice with no group.
         assert_fail_patch(
             "
@@ -665,9 +665,9 @@ mod test {
 - fixture: Dimmer
   patches:
     - addr: 2",
-            "duplicate group key 'Dimmer'",
+            "duplicate group name 'Dimmer'",
         );
-        // Can't use the same group key twice.
+        // Can't use the same group name twice.
         assert_fail_patch(
             "
 - fixture: Dimmer
@@ -678,20 +678,20 @@ mod test {
   group: Foo
   patches:
     - addr: 2",
-            "duplicate group key 'Foo'",
+            "duplicate group name 'Foo'",
         );
     }
 
     #[test]
     fn test_no_aliasing_fixture() {
-        // Can't use a group key that collides with a fixture name.
+        // Can't use a group name that collides with a fixture name.
         assert_fail_patch(
             "
 - fixture: Dimmer
   group: Color
   patches:
     - addr: 1",
-            "the group key 'Color' cannot be used because it is also a fixture name",
+            "the group name 'Color' cannot be used because it is also a fixture name",
         );
     }
 
@@ -788,7 +788,7 @@ mod test {
         // Renaming a group keeps its stable id, so repatching preserves its
         // fixture model state — the operator-typed name changed but the
         // controller knows it's the same group.
-        cfg[0].group = Some(FixtureGroupKey("NewColor".to_string()));
+        cfg[0].group = Some(GroupName("NewColor".to_string()));
 
         patch.repatch(&cfg)?;
         let new_bufs = render(&patch);
@@ -922,7 +922,7 @@ mod test {
             }
 
             // Create a fixture group to get its control descriptions.
-            let key = FixtureGroupKey(format!("test_{}", name));
+            let key = GroupName(format!("test_{}", name));
             let id = GroupId::new();
             let group = match (patcher.create_group)(id, key.clone(), Default::default()) {
                 Ok(g) => g,

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -20,6 +20,25 @@ pub use patcher::{
 
 pub use option::{AsPatchOption, NoOptions, OptionsMenu, PatchOption, enum_patch_option};
 
+/// Build an [`anyhow::Error`] describing an internal patch inconsistency.
+///
+/// Use this for error paths that can only be reached due to a programmer bug
+/// — a violated patch invariant rather than a user-input or config error. We
+/// surface these as ordinary errors (rather than panicking) so a show in
+/// progress can keep running, but the message format makes the diagnosis
+/// unambiguous and the unique code makes the originating site easy to grep.
+///
+/// `code` should be of the form `"PI-NNN"` and unique across the codebase.
+/// Pass a `format!(...)`-built `String` (or any `Display`) for `details` to
+/// include the local context (channel ids, group names, etc.) that made the
+/// invariant violation visible.
+pub fn patch_inconsistency(code: &'static str, details: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Error code: {code}. Internal patch inconsistency: {details}. \
+         This is a bug — please report to this application's developers."
+    )
+}
+
 /// Where a fixture group physically lives inside a `Patch`.
 ///
 /// Returned by name/id lookups so callers can both access the group and know
@@ -312,7 +331,12 @@ impl Patch {
             GroupLocation::Channel(c) => self.channels.get_mut(c.inner()),
             GroupLocation::NonChannel(i) => self.non_channel.get_mut(i),
         }
-        .ok_or_else(|| anyhow!("internal patch index inconsistency for {name}"))?;
+        .ok_or_else(|| {
+            patch_inconsistency(
+                "PI-001",
+                format!("by_name had {location:?} for '{name}' but the backing vec lookup failed"),
+            )
+        })?;
 
         Ok((group, channel_id))
     }

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -197,7 +197,7 @@ impl Patch {
         );
         ensure!(
             !self.by_id.contains_key(&cfg.id),
-            "duplicate group id '{}' for group '{group_name}'",
+            "duplicate group id '{:?}' for group '{group_name}'",
             cfg.id
         );
 
@@ -341,16 +341,6 @@ impl Patch {
         Ok((group, channel_id))
     }
 
-    /// Look up the group on a specific channel.
-    pub fn group_in_channel(&self, channel: ChannelId) -> Option<&FixtureGroup> {
-        self.channels.get(channel.inner())
-    }
-
-    /// Look up the group on a specific channel, mutably.
-    pub fn group_in_channel_mut(&mut self, channel: ChannelId) -> Option<&mut FixtureGroup> {
-        self.channels.get_mut(channel.inner())
-    }
-
     /// Look up the channel id for a group by stable id, or `None` if the group
     /// isn't channel-bound (or doesn't exist).
     pub fn channel_for_id(&self, id: GroupId) -> Option<ChannelId> {
@@ -364,21 +354,63 @@ impl Patch {
         self.channels.len()
     }
 
-    /// Validate that a channel index refers to a channel that actually exists.
-    pub fn validate_channel(&self, channel: usize) -> Result<ChannelId> {
-        if channel < self.channels.len() {
-            Ok(ChannelId::new(channel))
-        } else {
-            bail!(
-                "channel selector {channel} out of range, only {} channels are configured",
+    /// Validate a raw channel index (typically from an OSC payload) and return
+    /// the matching channel id paired with the group on that channel.
+    pub fn channel(&self, raw_id: usize) -> Result<(ChannelId, &FixtureGroup)> {
+        let group = self.channels.get(raw_id).ok_or_else(|| {
+            anyhow!(
+                "channel selector {raw_id} out of range, only {} channels are configured",
                 self.channels.len()
-            );
-        }
+            )
+        })?;
+        Ok((ChannelId::new(raw_id), group))
     }
 
-    /// Iterate over the valid channel ids, in channel order.
-    pub fn channel_ids(&self) -> impl Iterator<Item = ChannelId> + '_ {
-        (0..self.channels.len()).map(ChannelId::new)
+    /// Mutable counterpart to [`Patch::channel`].
+    pub fn channel_mut(&mut self, raw_id: usize) -> Result<(ChannelId, &mut FixtureGroup)> {
+        let len = self.channels.len();
+        let group = self.channels.get_mut(raw_id).ok_or_else(|| {
+            anyhow!("channel selector {raw_id} out of range, only {len} channels are configured")
+        })?;
+        Ok((ChannelId::new(raw_id), group))
+    }
+
+    /// Look up the group on a specific channel by trusted [`ChannelId`].
+    ///
+    /// A `ChannelId` can only be produced by methods on this `Patch` (either
+    /// [`channel`], [`channels_with_ids`], or [`channel_ids`]), so failure
+    /// here indicates a programmer bug rather than an invalid input — the
+    /// error is reported via [`patch_inconsistency`] so the show can keep
+    /// running.
+    pub fn channel_group(&self, channel: ChannelId) -> Result<&FixtureGroup> {
+        self.channels.get(channel.inner()).ok_or_else(|| {
+            patch_inconsistency(
+                "PI-002",
+                format!(
+                    "channel {channel} has no group in patch (channel_count = {})",
+                    self.channels.len()
+                ),
+            )
+        })
+    }
+
+    /// Mutable counterpart to [`Patch::channel_group`].
+    pub fn channel_group_mut(&mut self, channel: ChannelId) -> Result<&mut FixtureGroup> {
+        let len = self.channels.len();
+        self.channels.get_mut(channel.inner()).ok_or_else(|| {
+            patch_inconsistency(
+                "PI-003",
+                format!("channel {channel} has no group in patch (channel_count = {len})"),
+            )
+        })
+    }
+
+    /// Iterate over `(ChannelId, &FixtureGroup)` pairs in channel order.
+    pub fn channels_with_ids(&self) -> impl Iterator<Item = (ChannelId, &FixtureGroup)> + '_ {
+        self.channels
+            .iter()
+            .enumerate()
+            .map(|(i, g)| (ChannelId::new(i), g))
     }
 
     /// Iterate over the channel labels, in channel order. Uses each group's
@@ -519,15 +551,9 @@ mod test {
         )?;
         assert_eq!(2, cfg.len());
         let p = Patch::patch_all(&cfg)?;
-        let channel_ids: Vec<_> = p.channel_ids().collect();
-        assert_eq!(channel_ids.len(), 1);
-        let channel_id = channel_ids[0];
-        assert_eq!(
-            "Color",
-            p.group_in_channel(channel_id)
-                .map(|g| g.qualified_name().to_string())
-                .unwrap_or_default()
-        );
+        let channel_pairs: Vec<_> = p.channels_with_ids().collect();
+        assert_eq!(channel_pairs.len(), 1);
+        assert_eq!("Color", channel_pairs[0].1.qualified_name().to_string());
         assert_eq!(2, p.iter().count());
         let color_configs = p
             .group_by_name("Color")

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -26,6 +26,8 @@ pub use option::{AsPatchOption, NoOptions, OptionsMenu, PatchOption, enum_patch_
 /// whether it's bound to a channel. Locations are valid for the lifetime of
 /// the `Patch` they came from; a repatch builds a fresh `Patch` and invalidates
 /// any locations from the previous one.
+///
+/// In short - get these and use them immediately, don't store them anywhere.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GroupLocation {
     /// Channel-bound; index is the channel id (= position in `Patch::channels`).

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -252,9 +252,6 @@ impl Patch {
             }
         }
 
-        // Color organ initialization used to be deferred until all groups were
-        // patched. It's actually safe to do it now because a single group's
-        // fixture count is fixed by the time we reach this point.
         if cfg.color_organ {
             group.use_color_organ();
         }
@@ -292,7 +289,7 @@ impl Patch {
     /// Look up a group by its name. Exercised by tests; production OSC
     /// dispatch goes through [`lookup_mut_by_name`] which also returns the
     /// channel id.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn group_by_name(&self, name: &str) -> Option<&FixtureGroup> {
         match *self.by_name.get(name)? {
             GroupLocation::Channel(c) => self.channels.get(c.inner()),
@@ -301,8 +298,7 @@ impl Patch {
     }
 
     /// Look up a group by its name, also returning the channel id if it's
-    /// channel-bound. Hot path for OSC dispatch — single hash lookup plus a
-    /// direct Vec index.
+    /// channel-bound. Hot path for OSC dispatch.
     pub fn lookup_mut_by_name(
         &mut self,
         name: &str,
@@ -312,9 +308,12 @@ impl Patch {
             .get(name)
             .ok_or_else(|| anyhow!("fixture {name} not found in patch"))?;
         let channel_id = location.as_channel();
-        let group = self
-            .group_at_mut(location)
-            .ok_or_else(|| anyhow!("internal patch index inconsistency for {name}"))?;
+        let group = match location {
+            GroupLocation::Channel(c) => self.channels.get_mut(c.inner()),
+            GroupLocation::NonChannel(i) => self.non_channel.get_mut(i),
+        }
+        .ok_or_else(|| anyhow!("internal patch index inconsistency for {name}"))?;
+
         Ok((group, channel_id))
     }
 
@@ -375,15 +374,6 @@ impl Patch {
     /// Iterate over all patched fixture groups, mutably.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut FixtureGroup> {
         self.channels.iter_mut().chain(self.non_channel.iter_mut())
-    }
-
-    // ---- Private helpers ----------------------------------------------------
-
-    fn group_at_mut(&mut self, location: GroupLocation) -> Option<&mut FixtureGroup> {
-        match location {
-            GroupLocation::Channel(c) => self.channels.get_mut(c.inner()),
-            GroupLocation::NonChannel(i) => self.non_channel.get_mut(i),
-        }
     }
 }
 

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -68,7 +68,7 @@ pub struct Patch {
     /// O(1) lookup from stable id to physical location.
     by_id: HashMap<GroupId, GroupLocation>,
     /// O(1) lookup from group name to physical location.
-    by_name: HashMap<String, GroupLocation>,
+    by_name: HashMap<GroupName, GroupLocation>,
     /// Which DMX addrs already have a fixture patched in them.
     used_addrs: UsedAddrs,
 }
@@ -173,7 +173,7 @@ impl Patch {
         let group_name = GroupName(cfg.name().to_string());
 
         ensure!(
-            !self.by_name.contains_key(&group_name.0),
+            !self.by_name.contains_key(&group_name),
             "duplicate group name '{group_name}'"
         );
         ensure!(
@@ -270,7 +270,7 @@ impl Patch {
             GroupLocation::NonChannel(idx)
         };
         self.by_id.insert(id, location);
-        self.by_name.insert(group_name.0, location);
+        self.by_name.insert(group_name, location);
         Ok(())
     }
 

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -1,14 +1,12 @@
 //! Types and traits related to patching fixtures.
-use anyhow::{Context, Result, anyhow, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use itertools::Itertools;
-use ordermap::{OrderMap, OrderSet};
-use std::collections::HashMap;
-
-use anyhow::bail;
 use log::info;
+use std::collections::HashMap;
 
 use super::fixture::FixtureType;
 use super::group::FixtureGroup;
+use crate::channel::ChannelId;
 use crate::config::{FixtureGroupConfig, FixtureGroupKey, GroupId};
 use crate::dmx::UniverseIdx;
 use crate::fixture::group::GroupFixtureConfig;
@@ -22,24 +20,55 @@ pub use patcher::{
 
 pub use option::{AsPatchOption, NoOptions, OptionsMenu, PatchOption, enum_patch_option};
 
+/// Where a fixture group physically lives inside a `Patch`.
+///
+/// Returned by name/id lookups so callers can both access the group and know
+/// whether it's bound to a channel. Locations are valid for the lifetime of
+/// the `Patch` they came from; a repatch builds a fresh `Patch` and invalidates
+/// any locations from the previous one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GroupLocation {
+    /// Channel-bound; index is the channel id (= position in `Patch::channels`).
+    Channel(ChannelId),
+    /// Not bound to a channel; index is the position in `Patch::non_channel`.
+    NonChannel(usize),
+}
+
+impl GroupLocation {
+    /// Return the channel id if this group is channel-bound, else `None`.
+    pub fn as_channel(&self) -> Option<ChannelId> {
+        match self {
+            Self::Channel(c) => Some(*c),
+            Self::NonChannel(_) => None,
+        }
+    }
+}
+
 /// Factory for fixture instances.
 ///
-/// Creates fixture instances based on configurations.
-/// Maintains a mapping of which DMX addresses are in use by which fixture, to
-/// prevent addressing collisions.
+/// Owns the fixture groups themselves and the indices used to look them up by
+/// display name, stable id, or channel position. Maintains a mapping of which
+/// DMX addresses are in use by which fixture, to prevent addressing collisions.
+///
+/// Storage layout: groups physically live in either `channels` (in channel
+/// order) or `non_channel` (not channel-bound). The `by_id` and `by_name`
+/// maps hold `GroupLocation`s that point into one of those two `Vec`s. This
+/// gives O(1) lookup by id, name, and channel position; iteration over all
+/// groups chains the two `Vec`s.
 pub struct Patch {
     /// Map of registered patchers.
     patchers: HashMap<String, Patcher>,
-
-    /// The fixture groups we've patched, keyed by stable identity.
-    /// Iteration order matches the order groups appear in the patch config.
-    fixtures: OrderMap<GroupId, FixtureGroup>,
+    /// Channel-bound groups in channel order. Position in this `Vec` IS the
+    /// `ChannelId`.
+    channels: Vec<FixtureGroup>,
+    /// Groups that are not bound to a channel (controlled only via OSC by name).
+    non_channel: Vec<FixtureGroup>,
+    /// O(1) lookup from stable id to physical location.
+    by_id: HashMap<GroupId, GroupLocation>,
+    /// O(1) lookup from display name to physical location.
+    by_name: HashMap<String, GroupLocation>,
     /// Which DMX addrs already have a fixture patched in them.
     used_addrs: UsedAddrs,
-    /// The channels that fixture groups are assigned to.
-    channels: OrderSet<GroupId>,
-    /// Initialize color organs for these fixture groups.
-    color_organs: OrderSet<GroupId>,
 }
 
 impl Patch {
@@ -63,10 +92,11 @@ impl Patch {
         }
         Self {
             patchers,
-            fixtures: Default::default(),
+            channels: Vec::new(),
+            non_channel: Vec::new(),
+            by_id: HashMap::new(),
+            by_name: HashMap::new(),
             used_addrs: Default::default(),
-            channels: Default::default(),
-            color_organs: Default::default(),
         }
     }
 
@@ -94,46 +124,44 @@ impl Patch {
                 )
             })?;
         }
-        patch.initialize_color_organs();
         Ok(patch)
     }
 
-    /// Re-intialize a patch from new configs.
+    /// Re-initialize a patch from new configs.
     ///
-    /// This allows retaining all existing state for any groups that haven't
-    /// materially changed.
+    /// Groups whose stable `GroupId` matches one from the previous patch (and
+    /// whose fixture type and options are compatible) keep their live runtime
+    /// state — animation values, strobe state, etc. — via
+    /// [`FixtureGroup::reconfigure_from`]. Groups that don't match start fresh.
     ///
-    /// If any patch error occurs, we must ensure that the original patch remains
-    /// unchanged.
+    /// If any patch error occurs, the original patch remains unchanged.
     ///
     /// TODO: this approach will become problematic if we add control for any
     /// fixtures that require exclusive control of an external resource such as
     /// binding a socket.
     pub fn repatch(&mut self, groups: &[FixtureGroupConfig]) -> Result<()> {
         let mut new_patch = Self::patch_all(groups)?;
-        // Retain state from existing fixture models if they match.
-        // Reconciliation keys on the stable `GroupId`, so renaming a group
-        // (same id, different display key) carries state across.
-        // Since we're mutating the existing patch from here on out, we need to
-        // make sure that none of these operations can fail.
-        for (id, new) in new_patch.fixtures.iter_mut() {
-            let Some(existing) = self.fixtures.remove(id) else {
-                continue;
-            };
-            new.reconfigure_from(existing);
+        // Drain old groups into an id-keyed map for O(1) reconciliation lookup.
+        let mut old_by_id: HashMap<GroupId, FixtureGroup> = std::mem::take(&mut self.channels)
+            .into_iter()
+            .chain(std::mem::take(&mut self.non_channel))
+            .map(|g| (g.id(), g))
+            .collect();
+        for group in new_patch.iter_mut() {
+            if let Some(old) = old_by_id.remove(&group.id()) {
+                group.reconfigure_from(old);
+            }
         }
         *self = new_patch;
         Ok(())
     }
 
-    /// Patch a fixture group config.
-    ///
-    ///
+    /// Patch a single fixture group config.
     fn patch(&mut self, cfg: &FixtureGroupConfig) -> Result<()> {
         let patcher = self.patcher(&cfg.fixture)?;
 
         if let Some(group_key) = &cfg.group {
-            // If there's a patcher that matches this group, fail.
+            // If there's a patcher that matches this group name, fail.
             ensure!(
                 self.patcher(group_key).is_err(),
                 "the group key '{group_key}' cannot be used because it is also a fixture name"
@@ -143,11 +171,11 @@ impl Patch {
         let group_key = FixtureGroupKey(cfg.key().to_string());
 
         ensure!(
-            !self.fixtures.values().any(|g| g.key_str() == group_key.0),
+            !self.by_name.contains_key(&group_key.0),
             "duplicate group key '{group_key}'"
         );
         ensure!(
-            !self.fixtures.contains_key(&cfg.id),
+            !self.by_id.contains_key(&cfg.id),
             "duplicate group id '{}' for group '{group_key}'",
             cfg.id
         );
@@ -222,31 +250,26 @@ impl Patch {
             }
         }
 
-        let id = group.id();
-        self.fixtures.insert(id, group);
-
-        if cfg.channel {
-            self.channels.insert(id);
-        }
+        // Color organ initialization used to be deferred until all groups were
+        // patched. It's actually safe to do it now because a single group's
+        // fixture count is fixed by the time we reach this point.
         if cfg.color_organ {
-            self.color_organs.insert(id);
+            group.use_color_organ();
         }
+
+        let id = group.id();
+        let location = if cfg.channel {
+            let channel_id = ChannelId::new(self.channels.len());
+            self.channels.push(group);
+            GroupLocation::Channel(channel_id)
+        } else {
+            let idx = self.non_channel.len();
+            self.non_channel.push(group);
+            GroupLocation::NonChannel(idx)
+        };
+        self.by_id.insert(id, location);
+        self.by_name.insert(group_key.0, location);
         Ok(())
-    }
-
-    /// Iterate over the stable group ids assigned to each channel, in channel order.
-    pub fn channels(&self) -> impl Iterator<Item = GroupId> + '_ {
-        self.channels.iter().copied()
-    }
-
-    /// Initialize color organs for all fixtures that should have them.
-    ///
-    /// This should be called after all fixtures are patched.
-    /// TODO: update the color organ codebase to handle a change in fixture count.
-    fn initialize_color_organs(&mut self) {
-        for id in &self.color_organs {
-            self.fixtures[id].use_color_organ();
-        }
     }
 
     /// Dynamically get the universe count.
@@ -254,8 +277,7 @@ impl Patch {
     /// This is just based on the indices provided by fixtures; we could have
     /// "holes" where we don't actually have any fixtures patched.
     pub fn universe_count(&self) -> usize {
-        self.fixtures
-            .values()
+        self.iter()
             .flat_map(|group| group.fixture_configs())
             .map(|cfg| cfg.universe)
             .max()
@@ -263,41 +285,103 @@ impl Patch {
             + 1
     }
 
-    /// Get a fixture group by its display name. Used by OSC entry points where
-    /// the address provides a name string.
-    pub fn get(&self, key: &str) -> Result<&FixtureGroup> {
-        self.fixtures
-            .values()
-            .find(|g| g.key_str() == key)
-            .ok_or_else(|| anyhow!("fixture {key} not found in patch"))
+    // ---- Lookups ------------------------------------------------------------
+
+    /// Look up a group by its display name (the OSC-facing name).
+    /// Exercised by tests; production OSC dispatch goes through
+    /// [`lookup_mut_by_name`] which also returns the channel id.
+    #[allow(dead_code)]
+    pub fn group_by_name(&self, name: &str) -> Option<&FixtureGroup> {
+        match *self.by_name.get(name)? {
+            GroupLocation::Channel(c) => self.channels.get(c.inner()),
+            GroupLocation::NonChannel(i) => self.non_channel.get(i),
+        }
     }
 
-    /// Get a fixture group by display name, mutably.
-    pub fn get_mut(&mut self, key: &str) -> Result<&mut FixtureGroup> {
-        self.fixtures
-            .values_mut()
-            .find(|g| g.key_str() == key)
-            .ok_or_else(|| anyhow!("fixture {key} not found in patch"))
+    /// Look up a group by its display name, also returning the channel id if
+    /// it's channel-bound. Hot path for OSC dispatch — single hash lookup
+    /// plus a direct Vec index.
+    pub fn lookup_mut_by_name(
+        &mut self,
+        name: &str,
+    ) -> Result<(&mut FixtureGroup, Option<ChannelId>)> {
+        let location = *self
+            .by_name
+            .get(name)
+            .ok_or_else(|| anyhow!("fixture {name} not found in patch"))?;
+        let channel_id = location.as_channel();
+        let group = self
+            .group_at_mut(location)
+            .ok_or_else(|| anyhow!("internal patch index inconsistency for {name}"))?;
+        Ok((group, channel_id))
     }
 
-    /// Get a fixture group by its stable id.
-    pub fn get_by_id(&self, id: GroupId) -> Option<&FixtureGroup> {
-        self.fixtures.get(&id)
+    /// Look up the group on a specific channel.
+    pub fn group_in_channel(&self, channel: ChannelId) -> Option<&FixtureGroup> {
+        self.channels.get(channel.inner())
     }
 
-    /// Get a fixture group by its stable id, mutably.
-    pub fn get_mut_by_id(&mut self, id: GroupId) -> Option<&mut FixtureGroup> {
-        self.fixtures.get_mut(&id)
+    /// Look up the group on a specific channel, mutably.
+    pub fn group_in_channel_mut(&mut self, channel: ChannelId) -> Option<&mut FixtureGroup> {
+        self.channels.get_mut(channel.inner())
     }
 
-    /// Iterate over all patched fixtures.
+    /// Look up the channel id for a group by stable id, or `None` if the group
+    /// isn't channel-bound (or doesn't exist).
+    pub fn channel_for_id(&self, id: GroupId) -> Option<ChannelId> {
+        self.by_id.get(&id)?.as_channel()
+    }
+
+    // ---- Channel queries ----------------------------------------------------
+
+    /// Number of channels in this patch.
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Validate that a channel index refers to a channel that actually exists.
+    pub fn validate_channel(&self, channel: usize) -> Result<ChannelId> {
+        if channel < self.channels.len() {
+            Ok(ChannelId::new(channel))
+        } else {
+            bail!(
+                "channel selector {channel} out of range, only {} channels are configured",
+                self.channels.len()
+            );
+        }
+    }
+
+    /// Iterate over the valid channel ids, in channel order.
+    pub fn channel_ids(&self) -> impl Iterator<Item = ChannelId> + '_ {
+        (0..self.channels.len()).map(ChannelId::new)
+    }
+
+    /// Iterate over the channel labels, in channel order. Uses each group's
+    /// qualified name.
+    pub fn channel_labels(&self) -> impl Iterator<Item = String> + '_ {
+        self.channels.iter().map(|g| g.qualified_name().to_string())
+    }
+
+    // ---- All-groups iteration ----------------------------------------------
+
+    /// Iterate over all patched fixture groups (channel-bound first, then
+    /// non-channel).
     pub fn iter(&self) -> impl Iterator<Item = &FixtureGroup> {
-        self.fixtures.values()
+        self.channels.iter().chain(self.non_channel.iter())
     }
 
-    /// Iterate over all patched fixtures, mutably.
+    /// Iterate over all patched fixture groups, mutably.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut FixtureGroup> {
-        self.fixtures.values_mut()
+        self.channels.iter_mut().chain(self.non_channel.iter_mut())
+    }
+
+    // ---- Private helpers ----------------------------------------------------
+
+    fn group_at_mut(&mut self, location: GroupLocation) -> Option<&mut FixtureGroup> {
+        match location {
+            GroupLocation::Channel(c) => self.channels.get_mut(c.inner()),
+            GroupLocation::NonChannel(i) => self.non_channel.get_mut(i),
+        }
     }
 }
 
@@ -419,10 +503,20 @@ mod test {
         )?;
         assert_eq!(2, cfg.len());
         let p = Patch::patch_all(&cfg)?;
-        let channel_id = *p.channels.iter().exactly_one().unwrap();
-        assert_eq!("Color", p.get_by_id(channel_id).unwrap().key_str());
-        assert_eq!(2, p.fixtures.len());
-        let color_configs = p.get("Color")?.fixture_configs();
+        let channel_ids: Vec<_> = p.channel_ids().collect();
+        assert_eq!(channel_ids.len(), 1);
+        let channel_id = channel_ids[0];
+        assert_eq!(
+            "Color",
+            p.group_in_channel(channel_id)
+                .map(|g| g.qualified_name().to_string())
+                .unwrap_or_default()
+        );
+        assert_eq!(2, p.iter().count());
+        let color_configs = p
+            .group_by_name("Color")
+            .ok_or_else(|| anyhow!("Color group missing"))?
+            .fixture_configs();
         assert_eq!(3, color_configs.len());
         assert_eq!(
             color_configs[0],
@@ -444,7 +538,10 @@ mod test {
                 render_mode: Some(ColorModel::DimmerRgb.render_mode()),
             }
         );
-        let dimmer_configs = p.get("TestGroup")?.fixture_configs();
+        let dimmer_configs = p
+            .group_by_name("TestGroup")
+            .ok_or_else(|| anyhow!("TestGroup missing"))?
+            .fixture_configs();
         assert_eq!(2, dimmer_configs.len());
         assert_eq!(
             dimmer_configs[0],

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -9,7 +9,7 @@ use log::info;
 
 use super::fixture::FixtureType;
 use super::group::FixtureGroup;
-use crate::config::{FixtureGroupConfig, FixtureGroupKey};
+use crate::config::{FixtureGroupConfig, FixtureGroupKey, GroupId};
 use crate::dmx::UniverseIdx;
 use crate::fixture::group::GroupFixtureConfig;
 
@@ -31,14 +31,15 @@ pub struct Patch {
     /// Map of registered patchers.
     patchers: HashMap<String, Patcher>,
 
-    /// The fixture groups we've patched.
-    fixtures: OrderMap<FixtureGroupKey, FixtureGroup>,
+    /// The fixture groups we've patched, keyed by stable identity.
+    /// Iteration order matches the order groups appear in the patch config.
+    fixtures: OrderMap<GroupId, FixtureGroup>,
     /// Which DMX addrs already have a fixture patched in them.
     used_addrs: UsedAddrs,
     /// The channels that fixture groups are assigned to.
-    channels: OrderSet<FixtureGroupKey>,
+    channels: OrderSet<GroupId>,
     /// Initialize color organs for these fixture groups.
-    color_organs: OrderSet<FixtureGroupKey>,
+    color_organs: OrderSet<GroupId>,
 }
 
 impl Patch {
@@ -111,10 +112,12 @@ impl Patch {
     pub fn repatch(&mut self, groups: &[FixtureGroupConfig]) -> Result<()> {
         let mut new_patch = Self::patch_all(groups)?;
         // Retain state from existing fixture models if they match.
+        // Reconciliation keys on the stable `GroupId`, so renaming a group
+        // (same id, different display key) carries state across.
         // Since we're mutating the existing patch from here on out, we need to
         // make sure that none of these operations can fail.
-        for (key, new) in new_patch.fixtures.iter_mut() {
-            let Some(existing) = self.fixtures.remove(key) else {
+        for (id, new) in new_patch.fixtures.iter_mut() {
+            let Some(existing) = self.fixtures.remove(id) else {
                 continue;
             };
             new.reconfigure_from(existing);
@@ -140,11 +143,16 @@ impl Patch {
         let group_key = FixtureGroupKey(cfg.key().to_string());
 
         ensure!(
-            !self.fixtures.contains_key(&group_key),
+            !self.fixtures.values().any(|g| g.key_str() == group_key.0),
             "duplicate group key '{group_key}'"
         );
+        ensure!(
+            !self.fixtures.contains_key(&cfg.id),
+            "duplicate group id '{}' for group '{group_key}'",
+            cfg.id
+        );
 
-        let mut group = (patcher.create_group)(group_key.clone(), cfg.options.clone())?;
+        let mut group = (patcher.create_group)(cfg.id, group_key.clone(), cfg.options.clone())?;
 
         ensure!(!cfg.patches.is_empty(), "no patches specified");
 
@@ -214,20 +222,21 @@ impl Patch {
             }
         }
 
-        self.fixtures.insert(group_key.clone(), group);
+        let id = group.id();
+        self.fixtures.insert(id, group);
 
         if cfg.channel {
-            self.channels.insert(group_key.clone());
+            self.channels.insert(id);
         }
         if cfg.color_organ {
-            self.color_organs.insert(group_key.clone());
+            self.color_organs.insert(id);
         }
         Ok(())
     }
 
-    /// Iterate over the fixture group keys assigned to each channel.
-    pub fn channels(&self) -> impl Iterator<Item = &FixtureGroupKey> + '_ {
-        self.channels.iter()
+    /// Iterate over the stable group ids assigned to each channel, in channel order.
+    pub fn channels(&self) -> impl Iterator<Item = GroupId> + '_ {
+        self.channels.iter().copied()
     }
 
     /// Initialize color organs for all fixtures that should have them.
@@ -235,8 +244,8 @@ impl Patch {
     /// This should be called after all fixtures are patched.
     /// TODO: update the color organ codebase to handle a change in fixture count.
     fn initialize_color_organs(&mut self) {
-        for key in &self.color_organs {
-            self.fixtures[key].use_color_organ();
+        for id in &self.color_organs {
+            self.fixtures[id].use_color_organ();
         }
     }
 
@@ -253,28 +262,37 @@ impl Patch {
             .unwrap_or_default()
             + 1
     }
-    /// Get the fixture/channel patched with this key.
+
+    /// Get a fixture group by its display name. Used by OSC entry points where
+    /// the address provides a name string.
     pub fn get(&self, key: &str) -> Result<&FixtureGroup> {
         self.fixtures
-            .get(key)
+            .values()
+            .find(|g| g.key_str() == key)
             .ok_or_else(|| anyhow!("fixture {key} not found in patch"))
     }
 
-    /// Get the fixture/channel patched with this key, mutably.
+    /// Get a fixture group by display name, mutably.
     pub fn get_mut(&mut self, key: &str) -> Result<&mut FixtureGroup> {
         self.fixtures
-            .get_mut(key)
+            .values_mut()
+            .find(|g| g.key_str() == key)
             .ok_or_else(|| anyhow!("fixture {key} not found in patch"))
+    }
+
+    /// Get a fixture group by its stable id.
+    pub fn get_by_id(&self, id: GroupId) -> Option<&FixtureGroup> {
+        self.fixtures.get(&id)
+    }
+
+    /// Get a fixture group by its stable id, mutably.
+    pub fn get_mut_by_id(&mut self, id: GroupId) -> Option<&mut FixtureGroup> {
+        self.fixtures.get_mut(&id)
     }
 
     /// Iterate over all patched fixtures.
     pub fn iter(&self) -> impl Iterator<Item = &FixtureGroup> {
         self.fixtures.values()
-    }
-
-    /// Iterate over all patched fixtures along with their keys.
-    pub fn iter_with_keys(&self) -> impl Iterator<Item = (&FixtureGroupKey, &FixtureGroup)> {
-        self.fixtures.iter()
     }
 
     /// Iterate over all patched fixtures, mutably.
@@ -401,10 +419,8 @@ mod test {
         )?;
         assert_eq!(2, cfg.len());
         let p = Patch::patch_all(&cfg)?;
-        assert_eq!(
-            "Color",
-            p.channels.iter().exactly_one().unwrap().to_string()
-        );
+        let channel_id = *p.channels.iter().exactly_one().unwrap();
+        assert_eq!("Color", p.get_by_id(channel_id).unwrap().key_str());
         assert_eq!(2, p.fixtures.len());
         let color_configs = p.get("Color")?.fixture_configs();
         assert_eq!(3, color_configs.len());
@@ -670,17 +686,19 @@ mod test {
 
         assert_eq!(render(&patch), twiddled);
 
-        // If we change the group names, repatching should force new models.
+        // Renaming a group keeps its stable id, so repatching preserves its
+        // fixture model state — the operator-typed name changed but the
+        // controller knows it's the same group.
         cfg[0].group = Some(FixtureGroupKey("NewColor".to_string()));
 
         patch.repatch(&cfg)?;
         let new_bufs = render(&patch);
         assert_eq!(2, new_bufs.len());
-        assert_eq!(new_bufs[0], initial[0]);
+        assert_eq!(
+            new_bufs[0], twiddled[0],
+            "renaming a group should preserve its state via stable GroupId"
+        );
         assert_eq!(new_bufs[1], twiddled[1]);
-
-        twiddle(patch.iter_mut().next().unwrap());
-        assert_eq!(twiddled, render(&patch));
 
         // Repatching with different patches should not force a new model.
         cfg[0].patches.truncate(1);
@@ -806,7 +824,8 @@ mod test {
 
             // Create a fixture group to get its control descriptions.
             let key = FixtureGroupKey(format!("test_{}", name));
-            let group = match (patcher.create_group)(key.clone(), Default::default()) {
+            let id = GroupId::new();
+            let group = match (patcher.create_group)(id, key.clone(), Default::default()) {
                 Ok(g) => g,
                 Err(_) => {
                     let menu = (patcher.group_options)();
@@ -816,7 +835,7 @@ mod test {
                     let options = Options::from_entries(
                         menu.iter().map(|(k, opt)| (k.clone(), opt.example_value())),
                     );
-                    match (patcher.create_group)(key.clone(), options) {
+                    match (patcher.create_group)(id, key.clone(), options) {
                         Ok(g) => g,
                         Err(_) => continue,
                     }

--- a/src/fixture/patch/patcher.rs
+++ b/src/fixture/patch/patcher.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use std::fmt::{Display, Write};
 
 use super::{OptionsMenu, PatchOption};
-use crate::config::{FixtureGroupKey, Options};
+use crate::config::{FixtureGroupKey, GroupId, Options};
 use crate::fixture::fixture::{
     AnimatedFixture, FixtureType, FixtureWithAnimations, NonAnimatedFixture, RenderMode,
 };
@@ -22,7 +22,7 @@ pub static PATCHERS: [Patcher];
 #[derive(Clone)]
 pub struct Patcher {
     pub name: FixtureType,
-    pub create_group: fn(FixtureGroupKey, Options) -> Result<FixtureGroup>,
+    pub create_group: fn(GroupId, FixtureGroupKey, Options) -> Result<FixtureGroup>,
     pub group_options: fn() -> Vec<(String, PatchOption)>,
     pub create_patch: fn(group_options: Options, patch_options: Options) -> Result<PatchConfig>,
     pub patch_options: fn() -> Vec<(String, PatchOption)>,
@@ -155,12 +155,13 @@ pub trait PatchFixture: Sized + 'static {
 /// Create a fixture group for a non-animated fixture.
 pub trait CreateNonAnimatedGroup: PatchFixture + NonAnimatedFixture + Sized + 'static {
     /// Create an empty fixture group for this type of fixture.
-    fn create_group(key: FixtureGroupKey, options: Options) -> Result<FixtureGroup>
+    fn create_group(id: GroupId, key: FixtureGroupKey, options: Options) -> Result<FixtureGroup>
     where
         <Self as PatchFixture>::GroupOptions: DeserializeOwned,
     {
         let fixture = Box::new(Self::create(options.clone())?);
         Ok(FixtureGroup::empty(
+            id,
             Self::NAME,
             key,
             fixture,
@@ -175,12 +176,13 @@ impl<T> CreateNonAnimatedGroup for T where T: PatchFixture + NonAnimatedFixture 
 /// Create a fixture group for an animated fixture.
 pub trait CreateAnimatedGroup: PatchFixture + AnimatedFixture + Sized + 'static {
     /// Create an empty fixture group for this type of fixture.
-    fn create_group(key: FixtureGroupKey, options: Options) -> Result<FixtureGroup>
+    fn create_group(id: GroupId, key: FixtureGroupKey, options: Options) -> Result<FixtureGroup>
     where
         <Self as PatchFixture>::GroupOptions: DeserializeOwned,
     {
         let fixture = Self::create(options.clone())?;
         Ok(FixtureGroup::empty(
+            id,
             Self::NAME,
             key,
             Box::new(FixtureWithAnimations {

--- a/src/fixture/patch/patcher.rs
+++ b/src/fixture/patch/patcher.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use std::fmt::{Display, Write};
 
 use super::{OptionsMenu, PatchOption};
-use crate::config::{FixtureGroupKey, GroupId, Options};
+use crate::config::{GroupId, GroupName, Options};
 use crate::fixture::fixture::{
     AnimatedFixture, FixtureType, FixtureWithAnimations, NonAnimatedFixture, RenderMode,
 };
@@ -22,7 +22,7 @@ pub static PATCHERS: [Patcher];
 #[derive(Clone)]
 pub struct Patcher {
     pub name: FixtureType,
-    pub create_group: fn(GroupId, FixtureGroupKey, Options) -> Result<FixtureGroup>,
+    pub create_group: fn(GroupId, GroupName, Options) -> Result<FixtureGroup>,
     pub group_options: fn() -> Vec<(String, PatchOption)>,
     pub create_patch: fn(group_options: Options, patch_options: Options) -> Result<PatchConfig>,
     pub patch_options: fn() -> Vec<(String, PatchOption)>,
@@ -155,7 +155,7 @@ pub trait PatchFixture: Sized + 'static {
 /// Create a fixture group for a non-animated fixture.
 pub trait CreateNonAnimatedGroup: PatchFixture + NonAnimatedFixture + Sized + 'static {
     /// Create an empty fixture group for this type of fixture.
-    fn create_group(id: GroupId, key: FixtureGroupKey, options: Options) -> Result<FixtureGroup>
+    fn create_group(id: GroupId, key: GroupName, options: Options) -> Result<FixtureGroup>
     where
         <Self as PatchFixture>::GroupOptions: DeserializeOwned,
     {
@@ -176,7 +176,7 @@ impl<T> CreateNonAnimatedGroup for T where T: PatchFixture + NonAnimatedFixture 
 /// Create a fixture group for an animated fixture.
 pub trait CreateAnimatedGroup: PatchFixture + AnimatedFixture + Sized + 'static {
     /// Create an empty fixture group for this type of fixture.
-    fn create_group(id: GroupId, key: FixtureGroupKey, options: Options) -> Result<FixtureGroup>
+    fn create_group(id: GroupId, key: GroupName, options: Options) -> Result<FixtureGroup>
     where
         <Self as PatchFixture>::GroupOptions: DeserializeOwned,
     {

--- a/src/fixture/profile/mod.rs
+++ b/src/fixture/profile/mod.rs
@@ -40,7 +40,7 @@ mod osc_control_test {
     use rosc::{OscMessage, OscType};
 
     use crate::channel::mock::no_op_emitter;
-    use crate::config::{FixtureGroupKey, Options};
+    use crate::config::{FixtureGroupKey, GroupId, Options};
     use crate::fixture::control::{OscControlDescription, OscControlType};
     use crate::fixture::patch::{PATCHERS, PatchOption};
     use crate::osc::{OscClientId, OscControlMessage};
@@ -134,8 +134,9 @@ mod osc_control_test {
             }
 
             let key = FixtureGroupKey(format!("test_{}", patcher.name));
+            let id = GroupId::new();
 
-            let mut group = match (patcher.create_group)(key.clone(), Default::default()) {
+            let mut group = match (patcher.create_group)(id, key.clone(), Default::default()) {
                 Ok(group) => group,
                 Err(_) => {
                     // Try again with example values from the options menu.
@@ -149,7 +150,7 @@ mod osc_control_test {
                         menu.iter()
                             .map(|(name, opt)| (name.clone(), opt.example_value())),
                     );
-                    (patcher.create_group)(key.clone(), options).unwrap_or_else(|e| {
+                    (patcher.create_group)(id, key.clone(), options).unwrap_or_else(|e| {
                         panic!(
                             "{}: create_group failed even with example options: {e}",
                             patcher.name

--- a/src/fixture/profile/mod.rs
+++ b/src/fixture/profile/mod.rs
@@ -40,7 +40,7 @@ mod osc_control_test {
     use rosc::{OscMessage, OscType};
 
     use crate::channel::mock::no_op_emitter;
-    use crate::config::{FixtureGroupKey, GroupId, Options};
+    use crate::config::{GroupId, GroupName, Options};
     use crate::fixture::control::{OscControlDescription, OscControlType};
     use crate::fixture::patch::{PATCHERS, PatchOption};
     use crate::osc::{OscClientId, OscControlMessage};
@@ -50,10 +50,7 @@ mod osc_control_test {
     const EXCLUDED_FIXTURES: &[&str] = &["RugDoctor"];
 
     /// Generate fuzz (addr, arg) pairs for a control based on its type.
-    fn fuzz_values(
-        key: &FixtureGroupKey,
-        control: &OscControlDescription,
-    ) -> Vec<(String, OscType)> {
+    fn fuzz_values(key: &GroupName, control: &OscControlDescription) -> Vec<(String, OscType)> {
         let base = format!("/{}/{}", key.0, control.name);
         match &control.control_type {
             OscControlType::Unipolar | OscControlType::Phase => vec![
@@ -133,7 +130,7 @@ mod osc_control_test {
                 continue;
             }
 
-            let key = FixtureGroupKey(format!("test_{}", patcher.name));
+            let key = GroupName(format!("test_{}", patcher.name));
             let id = GroupId::new();
 
             let mut group = match (patcher.create_group)(id, key.clone(), Default::default()) {

--- a/src/midi/device/launch_control_xl.rs
+++ b/src/midi/device/launch_control_xl.rs
@@ -6,7 +6,7 @@ use tunnels::{
     midi_controls::MidiDevice,
 };
 
-use crate::{channel::KnobValue, show::ChannelId};
+use crate::{channel::KnobValue, fixture::patch::ChannelId};
 
 /// Model of the Novation Launch Control XL.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/osc/mod.rs
+++ b/src/osc/mod.rs
@@ -1,5 +1,5 @@
 use crate::channel::{ChannelStateChange, ChannelStateEmitter};
-use crate::config::FixtureGroupKey;
+use crate::config::GroupName;
 use crate::control::ControlMessage;
 use crate::control::EmitControlMessage;
 use crate::midi::{EmitMidiAnimationMessage, EmitMidiMasterMessage};
@@ -128,16 +128,16 @@ impl OscController {
     }
 }
 
-/// Decorate a control message emitter to inject a group into the address.
+/// Decorate a control message emitter to inject a group name into the address.
 pub struct FixtureStateEmitter<'a> {
-    key: &'a FixtureGroupKey,
+    name: &'a GroupName,
     channel_emitter: ChannelStateEmitter<'a>,
 }
 
 impl<'a> FixtureStateEmitter<'a> {
-    pub fn new(key: &'a FixtureGroupKey, channel_emitter: ChannelStateEmitter<'a>) -> Self {
+    pub fn new(name: &'a GroupName, channel_emitter: ChannelStateEmitter<'a>) -> Self {
         Self {
-            key,
+            name,
             channel_emitter,
         }
     }
@@ -149,7 +149,7 @@ impl<'a> FixtureStateEmitter<'a> {
 
 impl<'a> EmitScopedOscMessage for FixtureStateEmitter<'a> {
     fn emit_osc(&self, msg: ScopedOscMessage) {
-        let addr = format!("/{}/{}", self.key, msg.control);
+        let addr = format!("/{}/{}", self.name, msg.control);
         self.channel_emitter.emit_osc(OscMessage {
             addr,
             args: vec![msg.arg],

--- a/src/show.rs
+++ b/src/show.rs
@@ -11,7 +11,8 @@ use crate::{
     control::{ControlMessage, Controller, MetaCommand, meta_command_from_osc},
     dmx::DmxUniverse,
     fixture::{
-        Patch, animation_target::ControllableTargetedAnimation, prelude::FixtureGroupUpdate,
+        Patch, animation_target::ControllableTargetedAnimation, patch::patch_inconsistency,
+        prelude::FixtureGroupUpdate,
     },
     gui_state::{AnimationSnapshot, DmxPortInfo, DmxPortStatus, PatchSnapshot},
     gui_state::{GuiDirty, SharedGuiState},
@@ -24,7 +25,7 @@ use crate::{
 pub use crate::channel::ChannelId;
 use tunnels::audio::EnvelopeStreams;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use color_organ::{HsluvColor, IgnoreEmitter};
 use log::error;
 use rust_dmx::{DmxPort, OfflineDmxPort};
@@ -349,10 +350,14 @@ impl Show {
                         "cannot handle animation control message because no channel is selected\n{msg:?}"
                     );
                 };
-                let group = self
-                    .patch
-                    .group_in_channel_mut(channel)
-                    .ok_or_else(|| anyhow!("no group in selected channel {channel}"))?;
+                let group = self.patch.group_in_channel_mut(channel).ok_or_else(|| {
+                    patch_inconsistency(
+                        "PI-004",
+                        format!(
+                            "animation control: selected channel {channel} has no group in patch"
+                        ),
+                    )
+                })?;
                 self.animation_ui_state.control(
                     msg,
                     channel,
@@ -408,10 +413,12 @@ impl Show {
                         "cannot handle animation control message because no channel is selected\n{msg:?}"
                     );
                 };
-                let group = self
-                    .patch
-                    .group_in_channel_mut(channel)
-                    .ok_or_else(|| anyhow!("no group in selected channel {channel}"))?;
+                let group = self.patch.group_in_channel_mut(channel).ok_or_else(|| {
+                    patch_inconsistency(
+                        "PI-005",
+                        format!("animation OSC: selected channel {channel} has no group in patch"),
+                    )
+                })?;
                 self.animation_ui_state.control_osc(
                     msg,
                     channel,
@@ -553,7 +560,13 @@ impl Show {
                 );
             } else {
                 error!(
-                    "Refreshing UI: could not get fixture group for current channel {current_channel}."
+                    "{}",
+                    patch_inconsistency(
+                        "PI-007",
+                        format!(
+                            "refresh_ui: selected channel {current_channel} has no group in patch"
+                        ),
+                    )
                 );
             }
         }
@@ -573,10 +586,14 @@ impl Show {
         let Some(current_channel) = self.channels.current_channel() else {
             return Ok(());
         };
-        let group = self
-            .patch
-            .group_in_channel(current_channel)
-            .ok_or_else(|| anyhow!("no group in selected channel {current_channel}"))?;
+        let group = self.patch.group_in_channel(current_channel).ok_or_else(|| {
+            patch_inconsistency(
+                "PI-006",
+                format!(
+                    "snapshot_animation_state: selected channel {current_channel} has no group in patch"
+                ),
+            )
+        })?;
         let animation_index = self
             .animation_ui_state
             .animation_index_for_channel(current_channel);

--- a/src/show.rs
+++ b/src/show.rs
@@ -11,8 +11,7 @@ use crate::{
     control::{ControlMessage, Controller, MetaCommand, meta_command_from_osc},
     dmx::DmxUniverse,
     fixture::{
-        Patch, animation_target::ControllableTargetedAnimation, patch::patch_inconsistency,
-        prelude::FixtureGroupUpdate,
+        Patch, animation_target::ControllableTargetedAnimation, prelude::FixtureGroupUpdate,
     },
     gui_state::{AnimationSnapshot, DmxPortInfo, DmxPortStatus, PatchSnapshot},
     gui_state::{GuiDirty, SharedGuiState},
@@ -292,7 +291,7 @@ impl Show {
     /// strobe, `None` if it is occupied by a fixture group.
     fn resolve_strobe_channel(&self) -> Option<usize> {
         let ch = strobe_control_channel(self.patch.channel_count());
-        if self.patch.validate_channel(ch).is_ok() {
+        if ch < self.patch.channel_count() {
             None // channel is occupied by a fixture group
         } else {
             Some(ch) // available
@@ -350,14 +349,7 @@ impl Show {
                         "cannot handle animation control message because no channel is selected\n{msg:?}"
                     );
                 };
-                let group = self.patch.group_in_channel_mut(channel).ok_or_else(|| {
-                    patch_inconsistency(
-                        "PI-004",
-                        format!(
-                            "animation control: selected channel {channel} has no group in patch"
-                        ),
-                    )
-                })?;
+                let group = self.patch.channel_group_mut(channel)?;
                 self.animation_ui_state.control(
                     msg,
                     channel,
@@ -413,12 +405,7 @@ impl Show {
                         "cannot handle animation control message because no channel is selected\n{msg:?}"
                     );
                 };
-                let group = self.patch.group_in_channel_mut(channel).ok_or_else(|| {
-                    patch_inconsistency(
-                        "PI-005",
-                        format!("animation OSC: selected channel {channel} has no group in patch"),
-                    )
-                })?;
+                let group = self.patch.channel_group_mut(channel)?;
                 self.animation_ui_state.control_osc(
                     msg,
                     channel,
@@ -549,25 +536,16 @@ impl Show {
         self.channels.emit_state(false, &self.patch, emitter);
 
         if let Some(current_channel) = self.channels.current_channel() {
-            if let Some(group) = self.patch.group_in_channel(current_channel) {
-                self.animation_ui_state.emit_state(
+            match self.patch.channel_group(current_channel) {
+                Ok(group) => self.animation_ui_state.emit_state(
                     current_channel,
                     group,
                     &ScopedControlEmitter {
                         entity: crate::osc::animation::GROUP,
                         emitter,
                     },
-                );
-            } else {
-                error!(
-                    "{}",
-                    patch_inconsistency(
-                        "PI-007",
-                        format!(
-                            "refresh_ui: selected channel {current_channel} has no group in patch"
-                        ),
-                    )
-                );
+                ),
+                Err(e) => error!("{e:#}"),
             }
         }
 
@@ -586,14 +564,7 @@ impl Show {
         let Some(current_channel) = self.channels.current_channel() else {
             return Ok(());
         };
-        let group = self.patch.group_in_channel(current_channel).ok_or_else(|| {
-            patch_inconsistency(
-                "PI-006",
-                format!(
-                    "snapshot_animation_state: selected channel {current_channel} has no group in patch"
-                ),
-            )
-        })?;
+        let group = self.patch.channel_group(current_channel)?;
         let animation_index = self
             .animation_ui_state
             .animation_index_for_channel(current_channel);

--- a/src/show.rs
+++ b/src/show.rs
@@ -62,7 +62,7 @@ impl Show {
         gui_state: SharedGuiState,
         envelope_streams_tx: Sender<EnvelopeStreams>,
     ) -> Result<Self> {
-        let channels = Channels::from_iter(patch.channels().cloned());
+        let channels = Channels::from_iter(patch.channels());
         let initial_channel = channels.current_channel();
         let animation_ui_state = AnimationUIState::new(initial_channel);
 
@@ -265,7 +265,7 @@ impl Show {
                 emitter: &sender,
             },
         );
-        self.channels = Channels::from_iter(self.patch.channels().cloned());
+        self.channels = Channels::from_iter(self.patch.channels());
         if self.master_strobe_channel.is_some() {
             // Re-resolve: channel may have moved to a new wing or become occupied.
             self.set_master_strobe_channel(self.resolve_strobe_channel());
@@ -424,13 +424,10 @@ impl Show {
             }
             // Assume any other control group is referring to a fixture group.
             fixture_group => {
-                self.patch.get_mut(fixture_group)?.control(
-                    msg,
-                    ChannelStateEmitter::new(
-                        self.channels.channel_for_fixture(fixture_group),
-                        &sender,
-                    ),
-                )?;
+                let channel_id = self.channels.channel_for_name(fixture_group, &self.patch);
+                self.patch
+                    .get_mut(fixture_group)?
+                    .control(msg, ChannelStateEmitter::new(channel_id, &sender))?;
                 Ok(GuiDirty::CLEAN)
             }
         }
@@ -529,9 +526,9 @@ impl Show {
     /// Send messages to refresh all UI state.
     fn refresh_ui(&mut self) {
         let emitter = &self.controller.sender_with_metadata(None);
-        for (key, group) in self.patch.iter_with_keys() {
+        for group in self.patch.iter() {
             group.emit_state(ChannelStateEmitter::new(
-                self.channels.channel_for_fixture(key),
+                self.channels.channel_for_id(group.id()),
                 emitter,
             ));
         }
@@ -665,7 +662,7 @@ impl Show {
     ) -> (Self, std::sync::mpsc::Sender<ControlMessage>) {
         let (controller, send) = Controller::test_new();
         let universe_count = patch.universe_count();
-        let channels = Channels::from_iter(patch.channels().cloned());
+        let channels = Channels::from_iter(patch.channels());
         let initial_channel = channels.current_channel();
         let (envelope_streams_tx, _envelope_rx) = std::sync::mpsc::channel();
         let clocks = build_clocks(envelope_streams_tx.clone());

--- a/src/show.rs
+++ b/src/show.rs
@@ -21,7 +21,6 @@ use crate::{
     preview::Previewer,
 };
 
-pub use crate::channel::ChannelId;
 use tunnels::audio::EnvelopeStreams;
 
 use anyhow::{Context, Result, bail};

--- a/src/show.rs
+++ b/src/show.rs
@@ -24,7 +24,7 @@ use crate::{
 pub use crate::channel::ChannelId;
 use tunnels::audio::EnvelopeStreams;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use color_organ::{HsluvColor, IgnoreEmitter};
 use log::error;
 use rust_dmx::{DmxPort, OfflineDmxPort};
@@ -62,7 +62,7 @@ impl Show {
         gui_state: SharedGuiState,
         envelope_streams_tx: Sender<EnvelopeStreams>,
     ) -> Result<Self> {
-        let channels = Channels::from_iter(patch.channels());
+        let channels = Channels::new(&patch);
         let initial_channel = channels.current_channel();
         let animation_ui_state = AnimationUIState::new(initial_channel);
 
@@ -265,7 +265,7 @@ impl Show {
                 emitter: &sender,
             },
         );
-        self.channels = Channels::from_iter(self.patch.channels());
+        self.channels.reconcile_to_patch(&self.patch);
         if self.master_strobe_channel.is_some() {
             // Re-resolve: channel may have moved to a new wing or become occupied.
             self.set_master_strobe_channel(self.resolve_strobe_channel());
@@ -290,8 +290,8 @@ impl Show {
     /// Returns `Some(channel_index)` if the last wing fader is available for
     /// strobe, `None` if it is occupied by a fixture group.
     fn resolve_strobe_channel(&self) -> Option<usize> {
-        let ch = strobe_control_channel(self.channels.channel_count());
-        if self.channels.validate_channel(ch).is_ok() {
+        let ch = strobe_control_channel(self.patch.channel_count());
+        if self.patch.validate_channel(ch).is_ok() {
             None // channel is occupied by a fixture group
         } else {
             Some(ch) // available
@@ -349,11 +349,14 @@ impl Show {
                         "cannot handle animation control message because no channel is selected\n{msg:?}"
                     );
                 };
+                let group = self
+                    .patch
+                    .group_in_channel_mut(channel)
+                    .ok_or_else(|| anyhow!("no group in selected channel {channel}"))?;
                 self.animation_ui_state.control(
                     msg,
                     channel,
-                    self.channels
-                        .group_by_channel_mut(&mut self.patch, channel)?,
+                    group,
                     &ScopedControlEmitter {
                         entity: crate::osc::animation::GROUP,
                         emitter: &sender,
@@ -405,11 +408,14 @@ impl Show {
                         "cannot handle animation control message because no channel is selected\n{msg:?}"
                     );
                 };
+                let group = self
+                    .patch
+                    .group_in_channel_mut(channel)
+                    .ok_or_else(|| anyhow!("no group in selected channel {channel}"))?;
                 self.animation_ui_state.control_osc(
                     msg,
                     channel,
-                    self.channels
-                        .group_by_channel_mut(&mut self.patch, channel)?,
+                    group,
                     &ScopedControlEmitter {
                         entity: crate::osc::animation::GROUP,
                         emitter: &sender,
@@ -424,10 +430,8 @@ impl Show {
             }
             // Assume any other control group is referring to a fixture group.
             fixture_group => {
-                let channel_id = self.channels.channel_for_name(fixture_group, &self.patch);
-                self.patch
-                    .get_mut(fixture_group)?
-                    .control(msg, ChannelStateEmitter::new(channel_id, &sender))?;
+                let (group, channel_id) = self.patch.lookup_mut_by_name(fixture_group)?;
+                group.control(msg, ChannelStateEmitter::new(channel_id, &sender))?;
                 Ok(GuiDirty::CLEAN)
             }
         }
@@ -514,7 +518,7 @@ impl Show {
     /// Reconcile MIDI submaster wing slots with the current channel count.
     fn reconcile_submaster_wings(&mut self) -> Result<()> {
         self.controller
-            .reconcile_submaster_wings(self.channels.channel_count())
+            .reconcile_submaster_wings(self.patch.channel_count())
     }
 
     /// Reconcile the clock wing slot with the current clock mode.
@@ -528,7 +532,7 @@ impl Show {
         let emitter = &self.controller.sender_with_metadata(None);
         for group in self.patch.iter() {
             group.emit_state(ChannelStateEmitter::new(
-                self.channels.channel_for_id(group.id()),
+                self.patch.channel_for_id(group.id()),
                 emitter,
             ));
         }
@@ -538,7 +542,7 @@ impl Show {
         self.channels.emit_state(false, &self.patch, emitter);
 
         if let Some(current_channel) = self.channels.current_channel() {
-            if let Ok(group) = self.channels.group_by_channel(&self.patch, current_channel) {
+            if let Some(group) = self.patch.group_in_channel(current_channel) {
                 self.animation_ui_state.emit_state(
                     current_channel,
                     group,
@@ -570,8 +574,9 @@ impl Show {
             return Ok(());
         };
         let group = self
-            .channels
-            .group_by_channel(&self.patch, current_channel)?;
+            .patch
+            .group_in_channel(current_channel)
+            .ok_or_else(|| anyhow!("no group in selected channel {current_channel}"))?;
         let animation_index = self
             .animation_ui_state
             .animation_index_for_channel(current_channel);
@@ -662,7 +667,7 @@ impl Show {
     ) -> (Self, std::sync::mpsc::Sender<ControlMessage>) {
         let (controller, send) = Controller::test_new();
         let universe_count = patch.universe_count();
-        let channels = Channels::from_iter(patch.channels());
+        let channels = Channels::new(&patch);
         let initial_channel = channels.current_channel();
         let (envelope_streams_tx, _envelope_rx) = std::sync::mpsc::channel();
         let clocks = build_clocks(envelope_streams_tx.clone());
@@ -971,7 +976,7 @@ mod tests {
     fn master_strobe_channel_routing() {
         // 1 dimmer = 1 channel, 1 wing, strobe on fader 7.
         let mut show = show_from_yaml(ONE_UNIVERSE_PATCH);
-        let strobe_ch = strobe_control_channel(show.channels.channel_count());
+        let strobe_ch = strobe_control_channel(show.patch.channel_count());
         assert_eq!(strobe_ch, 7);
 
         // Default strobe intensity is 1.0 (full).
@@ -1036,7 +1041,7 @@ mod tests {
         // 8 dimmers = all 8 faders on wing 1 occupied.
         let yaml = n_dimmer_yaml(8);
         let mut show = show_from_yaml(&yaml);
-        assert_eq!(show.channels.channel_count(), 8);
+        assert_eq!(show.patch.channel_count(), 8);
 
         let result = show.handle_meta_command(MetaCommand::SetMasterStrobeChannel(true));
         assert!(result.is_err());


### PR DESCRIPTION
A major overhaul of how the patch is handled, how repatching works, and how we fetch things from the patch.

- Introduce a UUID to each patch group, which is stable across renames. Use this to uniquely identify a group in most cases, rather than using the group name.
- Rename FixtureGroupKey to GroupName to make it more clear what it is.
- Restructure the patch to store groups "inside" a channels collection, to finally make channels a first-class citizen instead of something more like a labeling system.
- Improve the patch API to return things like IDs and the entity they refer to in a single action, to eliminate a lot of follow-up queries that introduce a fallible path that could only be taken by a patch inconsistency.
- Introduce a helper error function for indicating that an error is the result of a patch inconsistency.