### PR TITLE
positioner persistence

### DIFF
--- a/src/clocks.rs
+++ b/src/clocks.rs
@@ -11,7 +11,7 @@ use tunnels::{
 use crate::{
     clock_service::ClockService,
     control::Controller,
-    gui_state::{ClockStatus, GuiDirty},
+    gui_state::{ClockStatus, StateDirty},
     osc::{GroupControlMap, OscControlMessage},
 };
 
@@ -132,20 +132,20 @@ impl Clocks {
         &mut self,
         msg: &OscControlMessage,
         emitter: &mut Controller,
-    ) -> Result<GuiDirty> {
+    ) -> Result<StateDirty> {
         let Self::Internal {
             audio_input,
             audio_controls,
             ..
         } = self
         else {
-            return Ok(GuiDirty::CLEAN);
+            return Ok(StateDirty::CLEAN);
         };
         let Some((msg, _talkback)) = audio_controls.handle(msg)? else {
-            return Ok(GuiDirty::CLEAN);
+            return Ok(StateDirty::CLEAN);
         };
         audio_input.control(msg, emitter);
-        Ok(GuiDirty::AUDIO)
+        Ok(StateDirty::AUDIO)
     }
 
     /// Handle an audio control message.
@@ -153,12 +153,12 @@ impl Clocks {
         &mut self,
         msg: tunnels::audio::ControlMessage,
         emitter: &mut Controller,
-    ) -> GuiDirty {
+    ) -> StateDirty {
         let Self::Internal { audio_input, .. } = self else {
-            return GuiDirty::CLEAN;
+            return StateDirty::CLEAN;
         };
         audio_input.control(msg, emitter);
-        GuiDirty::AUDIO
+        StateDirty::AUDIO
     }
 
     /// Emit all current audio and clock state.
@@ -223,7 +223,7 @@ mod tests {
                 tunnels::audio::ControlMessage::ResetParameters,
                 &mut controller,
             ),
-            GuiDirty::CLEAN,
+            StateDirty::CLEAN,
         );
 
         let mut internal = internal_clocks();
@@ -232,7 +232,7 @@ mod tests {
                 tunnels::audio::ControlMessage::ResetParameters,
                 &mut controller,
             ),
-            GuiDirty::AUDIO,
+            StateDirty::AUDIO,
         );
     }
 
@@ -245,14 +245,14 @@ mod tests {
             Clocks::test_new()
                 .control_audio_osc(&msg, &mut controller)
                 .expect("recognized msg should not error"),
-            GuiDirty::CLEAN,
+            StateDirty::CLEAN,
         );
 
         assert_eq!(
             internal_clocks()
                 .control_audio_osc(&msg, &mut controller)
                 .expect("recognized msg should not error"),
-            GuiDirty::AUDIO,
+            StateDirty::AUDIO,
         );
     }
 

--- a/src/config_gui/mod.rs
+++ b/src/config_gui/mod.rs
@@ -319,7 +319,6 @@ impl eframe::App for ConsoleApp {
                     state: &mut self.patch_panel,
                     snapshot: &snapshot,
                     patchers: &self.patchers,
-                    show_file_path: &self.show_file_path,
                 }
                 .ui(ui);
             }
@@ -371,7 +370,9 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
             configs,
             bound,
         } => (path, configs, bound.socket, bound.port),
-        WelcomeResult::NewShow { path, bound } => (path, vec![], bound.socket, bound.port),
+        WelcomeResult::NewShow { path, bound } => {
+            (path, Default::default(), bound.socket, bound.port)
+        }
         WelcomeResult::Quit => return Ok(()),
     };
 
@@ -392,6 +393,8 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
         recv_control_msg,
     )?;
 
+    let show_file_path_for_show = show_file_path.clone();
+
     // Move-once values for the eframe creator closure.
     let mut startup = Some((
         controller,
@@ -399,6 +402,7 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
         bound_port,
         initial_configs,
         log_rx,
+        show_file_path_for_show,
     ));
 
     // Phase 3: Run the console GUI. GuiState construction (which needs a
@@ -416,8 +420,14 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
         Box::new(move |cc| {
             stage_theme::apply(&cc.egui_ctx);
 
-            let (controller, osc_local_ip, bound_port, initial_configs, log_rx) =
-                startup.take().expect("creator closure called once");
+            let (
+                controller,
+                osc_local_ip,
+                bound_port,
+                initial_configs,
+                log_rx,
+                show_file_path_for_show,
+            ) = startup.take().expect("creator closure called once");
 
             let repaint: RepaintSignal = {
                 let ctx = cc.egui_ctx.clone();
@@ -471,7 +481,7 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
             let show_gui_state = gui_state.clone();
             let show_envelope_tx = envelope_tx.clone();
             std::thread::spawn(move || {
-                let patch = match Patch::patch_all(&initial_configs) {
+                let patch = match Patch::patch_all(initial_configs) {
                     Ok(p) => p,
                     Err(e) => {
                         error!("Show patch error: {e:#}");
@@ -489,9 +499,10 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
                         return;
                     }
                 };
+                let show_path = crate::show_file::ShowPath::new(show_file_path_for_show);
                 let show = Show::new(
                     patch,
-                    initial_configs,
+                    Some(show_path),
                     controller,
                     dmx,
                     clocks,

--- a/src/config_gui/mod.rs
+++ b/src/config_gui/mod.rs
@@ -364,15 +364,12 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
     // conflict is recoverable via a prompt instead of crashing show init.
     let welcome_result = welcome::run_welcome(crate::osc::DEFAULT_RECEIVE_PORT)?;
 
-    let (show_file_path, initial_configs, osc_socket, bound_port) = match welcome_result {
-        WelcomeResult::LoadShow {
+    let (show_file_path, initial_show_file, osc_socket, bound_port) = match welcome_result {
+        WelcomeResult::Show {
             path,
-            configs,
+            show_file,
             bound,
-        } => (path, configs, bound.socket, bound.port),
-        WelcomeResult::NewShow { path, bound } => {
-            (path, Default::default(), bound.socket, bound.port)
-        }
+        } => (path, show_file, bound.socket, bound.port),
         WelcomeResult::Quit => return Ok(()),
     };
 
@@ -400,7 +397,7 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
         controller,
         osc_local_ip,
         bound_port,
-        initial_configs,
+        initial_show_file,
         log_rx,
         show_file_path_for_show,
     ));
@@ -424,7 +421,7 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
                 controller,
                 osc_local_ip,
                 bound_port,
-                initial_configs,
+                initial_show_file,
                 log_rx,
                 show_file_path_for_show,
             ) = startup.take().expect("creator closure called once");
@@ -481,7 +478,7 @@ pub fn run_console(log_rx: Receiver<LogRecord>) -> Result<()> {
             let show_gui_state = gui_state.clone();
             let show_envelope_tx = envelope_tx.clone();
             std::thread::spawn(move || {
-                let patch = match Patch::patch_all(initial_configs) {
+                let patch = match Patch::from_show_file(initial_show_file) {
                     Ok(p) => p,
                     Err(e) => {
                         error!("Show patch error: {e:#}");

--- a/src/config_gui/patch_panel/mod.rs
+++ b/src/config_gui/patch_panel/mod.rs
@@ -153,19 +153,9 @@ pub(crate) struct PatchPanel<'a> {
     pub state: &'a mut PatchPanelState,
     pub snapshot: &'a PatchSnapshot,
     pub patchers: &'a [Patcher],
-    pub show_file_path: &'a std::path::Path,
 }
 
 impl PatchPanel<'_> {
-    fn autosave(&mut self, configs: &[FixtureGroupConfig]) {
-        let show_file = crate::show_file::ShowFile {
-            patch: configs.to_vec(),
-        };
-        if let Err(e) = crate::show_file::save(self.show_file_path, &show_file) {
-            self.ctx.modal.show("Autosave Failed", format!("{e:#}"));
-        }
-    }
-
     pub fn ui(mut self, ui: &mut egui::Ui) {
         if self.state.working_copy.is_none() {
             self.state.working_copy = Some(PatchWorkingCopy::from_snapshot(
@@ -189,12 +179,7 @@ impl PatchPanel<'_> {
                                 return;
                             };
                             let configs = wc.configs();
-                            if self
-                                .ctx
-                                .send_command(MetaCommand::Repatch(configs.clone()))
-                                .is_ok()
-                            {
-                                self.autosave(&configs);
+                            if self.ctx.send_command(MetaCommand::Repatch(configs)).is_ok() {
                                 self.state.working_copy = None;
                                 self.state.add_fixture_form = None;
                                 self.state.add_fixture_group = None;
@@ -1124,7 +1109,9 @@ mod test {
     // -----------------------------------------------------------------------
 
     fn test_snapshot_empty() -> PatchSnapshot {
-        PatchSnapshot { groups: vec![] }
+        PatchSnapshot {
+            groups: Default::default(),
+        }
     }
 
     fn simple_block(addr: usize) -> PatchBlock {
@@ -1195,7 +1182,8 @@ mod test {
             groups: vec![
                 simple_group(None, &[1]),
                 simple_group(Some("BackSimple"), &[10, 11]),
-            ],
+            ]
+            .into(),
         }
     }
 
@@ -1208,7 +1196,8 @@ mod test {
                 ),
                 group_opts_group(Some("Effects")),
                 simple_group(None, &[50]),
-            ],
+            ]
+            .into(),
         }
     }
 
@@ -1248,7 +1237,8 @@ mod test {
                 color_organ: false,
                 patches: vec![simple_block(1)],
                 options: Options::default(),
-            }],
+            }]
+            .into(),
         };
         let wc = PatchWorkingCopy::from_snapshot(&snapshot, &test_patchers());
         assert_eq!(wc.groups[0].channel_counts, vec![0]);
@@ -1376,7 +1366,7 @@ mod test {
     #[test]
     fn address_map_detects_collision() {
         let snapshot = PatchSnapshot {
-            groups: vec![simple_group(Some("A"), &[1]), simple_group(Some("B"), &[1])],
+            groups: vec![simple_group(Some("A"), &[1]), simple_group(Some("B"), &[1])].into(),
         };
         let wc = PatchWorkingCopy::from_snapshot(&snapshot, &test_patchers());
         let map = AddressMap::from_working_copy(&wc);
@@ -1405,7 +1395,8 @@ mod test {
                     }],
                     options: Options::default(),
                 },
-            ],
+            ]
+            .into(),
         };
         let wc = PatchWorkingCopy::from_snapshot(&snapshot, &test_patchers());
         let map = AddressMap::from_working_copy(&wc);
@@ -1416,7 +1407,7 @@ mod test {
     #[test]
     fn address_map_multi_channel_fixture() {
         let snapshot = PatchSnapshot {
-            groups: vec![patch_opts_group(None, vec![patch_opts_block(10, "Wide")])],
+            groups: vec![patch_opts_group(None, vec![patch_opts_block(10, "Wide")])].into(),
         };
         let wc = PatchWorkingCopy::from_snapshot(&snapshot, &test_patchers());
         let map = AddressMap::from_working_copy(&wc);
@@ -1442,7 +1433,7 @@ mod test {
     #[test]
     fn find_available_wraps_around() {
         let snapshot = PatchSnapshot {
-            groups: vec![simple_group(None, &(500..=512).collect::<Vec<_>>())],
+            groups: vec![simple_group(None, &(500..=512).collect::<Vec<_>>())].into(),
         };
         let wc = PatchWorkingCopy::from_snapshot(&snapshot, &test_patchers());
         let map = AddressMap::from_working_copy(&wc);
@@ -1452,7 +1443,7 @@ mod test {
     #[test]
     fn find_available_returns_none_when_full() {
         let snapshot = PatchSnapshot {
-            groups: vec![simple_group(None, &(1..=512).collect::<Vec<_>>())],
+            groups: vec![simple_group(None, &(1..=512).collect::<Vec<_>>())].into(),
         };
         let wc = PatchWorkingCopy::from_snapshot(&snapshot, &test_patchers());
         let map = AddressMap::from_working_copy(&wc);
@@ -1499,7 +1490,6 @@ mod test {
                 state,
                 snapshot,
                 patchers,
-                show_file_path: std::path::Path::new(""),
             }
             .ui(ui);
         });
@@ -1535,7 +1525,9 @@ mod test {
         let groups: Vec<_> = (0..10)
             .map(|i| simple_group(Some(&format!("Group{i}")), &[i * 10 + 1]))
             .collect();
-        let snapshot = PatchSnapshot { groups };
+        let snapshot = PatchSnapshot {
+            groups: groups.into(),
+        };
         let mut state = PatchPanelState::new();
         state.selected_group = Some(0);
         snapshot_panel(
@@ -1681,7 +1673,6 @@ mod test {
                 state: &mut state,
                 snapshot: &snapshot,
                 patchers: &patchers,
-                show_file_path: std::path::Path::new(""),
             }
             .ui(ui);
         });
@@ -1721,7 +1712,7 @@ mod test {
     fn commit_add_fixture_non_dmx() {
         let patchers = test_patchers();
         let snapshot = PatchSnapshot {
-            groups: vec![non_dmx_group(Some("MyNonDmx"))],
+            groups: vec![non_dmx_group(Some("MyNonDmx"))].into(),
         };
         let mut state = PatchPanelState::new();
         setup_add_fixture(&snapshot, &patchers, 0, &mut state);
@@ -1747,7 +1738,6 @@ mod test {
             state: &mut state,
             snapshot: &snapshot,
             patchers: &patchers,
-            show_file_path: std::path::Path::new(""),
         };
         panel.commit_add_fixture(0);
 
@@ -1775,7 +1765,6 @@ mod test {
             state: &mut state,
             snapshot: &snapshot,
             patchers: &patchers,
-            show_file_path: std::path::Path::new(""),
         };
         panel.commit_add_fixture(0);
 

--- a/src/config_gui/patch_panel/working_copy.rs
+++ b/src/config_gui/patch_panel/working_copy.rs
@@ -1,6 +1,7 @@
 use crate::config::{FixtureGroupConfig, PatchBlock};
 use crate::fixture::patch::Patcher;
 use crate::gui_state::PatchSnapshot;
+use crate::show_file::ShowPatchConfigs;
 
 pub(crate) struct WorkingGroup {
     pub config: FixtureGroupConfig,
@@ -36,8 +37,12 @@ impl PatchWorkingCopy {
         }
     }
 
-    pub fn configs(&self) -> Vec<FixtureGroupConfig> {
-        self.groups.iter().map(|g| g.config.clone()).collect()
+    pub fn configs(&self) -> ShowPatchConfigs {
+        self.groups
+            .iter()
+            .map(|g| g.config.clone())
+            .collect::<Vec<_>>()
+            .into()
     }
 }
 

--- a/src/config_gui/welcome.rs
+++ b/src/config_gui/welcome.rs
@@ -4,10 +4,9 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use eframe::egui;
 
-use crate::config::FixtureGroupConfig;
 use crate::fixture::Patch;
 use crate::osc::BoundOsc;
-use crate::show_file::{self, ShowFile};
+use crate::show_file::{self, ShowFile, ShowPatchConfigs};
 use gui_common::MessageModal;
 
 /// The result of the welcome screen interaction.
@@ -16,7 +15,7 @@ pub(crate) enum WelcomeResult {
     /// User chose to load an existing show file (validated).
     LoadShow {
         path: PathBuf,
-        configs: Vec<FixtureGroupConfig>,
+        configs: ShowPatchConfigs,
         bound: BoundOsc,
     },
     /// User chose to create a new, empty show.
@@ -29,7 +28,7 @@ pub(crate) enum WelcomeResult {
 struct PendingShow {
     path: PathBuf,
     /// Fixture configs for a loaded show; empty for a new show.
-    configs: Vec<FixtureGroupConfig>,
+    configs: ShowPatchConfigs,
     /// Whether this selection creates a new, empty show.
     new: bool,
 }
@@ -146,7 +145,7 @@ impl WelcomeApp {
         };
 
         // Validate the patch by building it (discards the result — Patch isn't Send).
-        if let Err(e) = Patch::patch_all(&show_file.patch) {
+        if let Err(e) = Patch::patch_all(show_file.patch.clone()) {
             self.modal.show("Invalid Show File", format!("{e:#}"));
             return;
         }
@@ -170,7 +169,9 @@ impl WelcomeApp {
             return;
         };
 
-        let empty = ShowFile { patch: vec![] };
+        let empty = ShowFile {
+            patch: ShowPatchConfigs::default(),
+        };
         if let Err(e) = show_file::save(&path, &empty) {
             self.modal.show("Failed to Create Show", format!("{e:#}"));
             return;
@@ -180,7 +181,7 @@ impl WelcomeApp {
             ctx,
             PendingShow {
                 path,
-                configs: vec![],
+                configs: ShowPatchConfigs::default(),
                 new: true,
             },
         );

--- a/src/config_gui/welcome.rs
+++ b/src/config_gui/welcome.rs
@@ -157,10 +157,7 @@ impl WelcomeApp {
             return;
         };
 
-        let show_file = ShowFile {
-            patch: Default::default(),
-            positioners: Default::default(),
-        };
+        let show_file = ShowFile::default();
         if let Err(e) = show_file::save(&path, &show_file) {
             self.modal.show("Failed to Create Show", format!("{e:#}"));
             return;

--- a/src/config_gui/welcome.rs
+++ b/src/config_gui/welcome.rs
@@ -6,20 +6,18 @@ use eframe::egui;
 
 use crate::fixture::Patch;
 use crate::osc::BoundOsc;
-use crate::show_file::{self, ShowFile, ShowPatchConfigs};
+use crate::show_file::{self, ShowFile};
 use gui_common::MessageModal;
 
 /// The result of the welcome screen interaction.
 #[derive(Debug)]
 pub(crate) enum WelcomeResult {
-    /// User chose to load an existing show file (validated).
-    LoadShow {
+    /// User chose a show file (loaded or freshly-created), validated.
+    Show {
         path: PathBuf,
-        configs: ShowPatchConfigs,
+        show_file: ShowFile,
         bound: BoundOsc,
     },
-    /// User chose to create a new, empty show.
-    NewShow { path: PathBuf, bound: BoundOsc },
     /// User closed the welcome window without choosing.
     Quit,
 }
@@ -27,10 +25,7 @@ pub(crate) enum WelcomeResult {
 /// A validated show selection held while the OSC port prompt is open.
 struct PendingShow {
     path: PathBuf,
-    /// Fixture configs for a loaded show; empty for a new show.
-    configs: ShowPatchConfigs,
-    /// Whether this selection creates a new, empty show.
-    new: bool,
+    show_file: ShowFile,
 }
 
 struct WelcomeApp {
@@ -150,14 +145,7 @@ impl WelcomeApp {
             return;
         }
 
-        self.choose(
-            ctx,
-            PendingShow {
-                path,
-                configs: show_file.patch,
-                new: false,
-            },
-        );
+        self.choose(ctx, PendingShow { path, show_file });
     }
 
     fn handle_new(&mut self, ctx: &egui::Context) {
@@ -169,22 +157,16 @@ impl WelcomeApp {
             return;
         };
 
-        let empty = ShowFile {
-            patch: ShowPatchConfigs::default(),
+        let show_file = ShowFile {
+            patch: Default::default(),
+            positioners: Default::default(),
         };
-        if let Err(e) = show_file::save(&path, &empty) {
+        if let Err(e) = show_file::save(&path, &show_file) {
             self.modal.show("Failed to Create Show", format!("{e:#}"));
             return;
         }
 
-        self.choose(
-            ctx,
-            PendingShow {
-                path,
-                configs: ShowPatchConfigs::default(),
-                new: true,
-            },
-        );
+        self.choose(ctx, PendingShow { path, show_file });
     }
 
     /// Record a chosen show and attempt to bind the OSC port, finalizing on
@@ -206,17 +188,10 @@ impl WelcomeApp {
                 let Some(pending) = self.pending.take() else {
                     return;
                 };
-                let result = if pending.new {
-                    WelcomeResult::NewShow {
-                        path: pending.path,
-                        bound,
-                    }
-                } else {
-                    WelcomeResult::LoadShow {
-                        path: pending.path,
-                        configs: pending.configs,
-                        bound,
-                    }
+                let result = WelcomeResult::Show {
+                    path: pending.path,
+                    show_file: pending.show_file,
+                    bound,
                 };
                 *self.result.lock().expect("welcome result mutex poisoned") = Some(result);
                 ctx.send_viewport_cmd(egui::ViewportCommand::Close);

--- a/src/control.rs
+++ b/src/control.rs
@@ -329,8 +329,8 @@ pub enum MetaCommand {
     UseInternalClocks(Option<String>),
     RegisterOscClient(OscClientId),
     DropOscClient(OscClientId),
-    /// Apply a new patch configuration from the GUI editor.
-    Repatch(Vec<crate::config::FixtureGroupConfig>),
+    /// Replace the patch configuration.
+    Repatch(crate::show_file::ShowPatchConfigs),
     /// Enable or disable the master strobe fader channel.
     SetMasterStrobeChannel(bool),
     /// Forward an audio control message to the active audio input.

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -1,6 +1,6 @@
 //! Define groups of fixtures, sharing a common fixture
 
-use anyhow::{Context, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use color_organ::ColorOrganHsluv;
 use color_organ::FixtureId;
 use log::error;
@@ -139,21 +139,17 @@ impl FixtureGroup {
         }
     }
 
-    /// Whether this group's fixture type supports the positioner.
-    pub fn supports_positioner(&self) -> bool {
-        self.fixture.supports_positioner()
-    }
-
-    /// Install loaded preset slots on this group's positioner. Caller is
-    /// responsible for checking [`Self::supports_positioner`] first;
-    /// passing presets to a non-positionable group silently drops them.
+    /// Install loaded preset slots on this group's positioner. Errors if
+    /// this group's fixture type doesn't support the positioner.
     pub(crate) fn install_positioner_presets(
         &mut self,
         presets: crate::positioner::PositionerPresets,
-    ) {
-        if let Some(positioner) = &mut self.positioner {
-            positioner.install_presets(presets);
-        }
+    ) -> Result<()> {
+        let Some(positioner) = &mut self.positioner else {
+            bail!("fixture type does not support the positioner");
+        };
+        positioner.install_presets(presets);
+        Ok(())
     }
 
     /// Get a mutable reference to the group's color organ, if in use.

--- a/src/fixture/group.rs
+++ b/src/fixture/group.rs
@@ -139,6 +139,23 @@ impl FixtureGroup {
         }
     }
 
+    /// Whether this group's fixture type supports the positioner.
+    pub fn supports_positioner(&self) -> bool {
+        self.fixture.supports_positioner()
+    }
+
+    /// Install loaded preset slots on this group's positioner. Caller is
+    /// responsible for checking [`Self::supports_positioner`] first;
+    /// passing presets to a non-positionable group silently drops them.
+    pub(crate) fn install_positioner_presets(
+        &mut self,
+        presets: crate::positioner::PositionerPresets,
+    ) {
+        if let Some(positioner) = &mut self.positioner {
+            positioner.install_presets(presets);
+        }
+    }
+
     /// Get a mutable reference to the group's color organ, if in use.
     pub fn color_organ_mut(&mut self) -> Option<&mut ColorOrganHsluv> {
         self.color_organ.as_mut()

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -186,17 +186,8 @@ impl Patch {
         Ok(())
     }
 
-    /// The configs that built this patch.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "slice view; pending callers in later pieces")
-    )]
-    pub fn configs(&self) -> &[FixtureGroupConfig] {
-        &self.configs
-    }
-
     /// A cheap-clone handle to the configs that built this patch.
-    pub fn configs_arc(&self) -> ShowPatchConfigs {
+    pub fn configs(&self) -> ShowPatchConfigs {
         Arc::clone(&self.configs)
     }
 

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -12,6 +12,7 @@ use super::group::FixtureGroup;
 use crate::config::{FixtureGroupConfig, GroupId, GroupName};
 use crate::dmx::UniverseIdx;
 use crate::fixture::group::GroupFixtureConfig;
+use crate::positioner::PositionerPresets;
 use crate::show_file::ShowPatchConfigs;
 
 mod option;
@@ -197,6 +198,42 @@ impl Patch {
     /// A cheap-clone handle to the configs that built this patch.
     pub fn configs_arc(&self) -> ShowPatchConfigs {
         Arc::clone(&self.configs)
+    }
+
+    /// Build a patch from a loaded show file, applying its positioner state
+    /// to the patched groups.
+    pub fn from_show_file(show_file: crate::show_file::ShowFile) -> Result<Self> {
+        let mut patch = Self::patch_all(show_file.patch)?;
+        patch.apply_loaded_positioners(show_file.positioners);
+        Ok(patch)
+    }
+
+    /// Install loaded positioner presets on the patched groups. Each entry
+    /// is reconciled to the group's current fixture count before
+    /// installation. Entries for unknown or non-positionable groups are
+    /// logged and dropped.
+    fn apply_loaded_positioners(&mut self, positioners: HashMap<GroupId, PositionerPresets>) {
+        for (id, presets) in positioners {
+            let Some(location) = self.by_id.get(&id).copied() else {
+                log::warn!("Loaded positioner for unknown group {id:?}; dropping");
+                continue;
+            };
+            let group = match location {
+                GroupLocation::Channel(c) => self.channels.get_mut(c.inner()),
+                GroupLocation::NonChannel(i) => self.non_channel.get_mut(i),
+            };
+            let Some(group) = group else {
+                log::error!(
+                    "internal: by_id pointed at missing slot for group {id:?}; dropping positioner"
+                );
+                continue;
+            };
+            if !group.supports_positioner() {
+                log::warn!("Loaded positioner for non-positionable group {id:?}; dropping");
+                continue;
+            }
+            group.install_positioner_presets(presets);
+        }
     }
 
     /// Patch a single fixture group config.

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -5,12 +5,14 @@ use log::info;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::sync::Arc;
 
 use super::fixture::FixtureType;
 use super::group::FixtureGroup;
 use crate::config::{FixtureGroupConfig, GroupId, GroupName};
 use crate::dmx::UniverseIdx;
 use crate::fixture::group::GroupFixtureConfig;
+use crate::show_file::ShowPatchConfigs;
 
 mod option;
 mod patcher;
@@ -89,8 +91,10 @@ pub struct Patch {
     by_id: HashMap<GroupId, GroupLocation>,
     /// O(1) lookup from group name to physical location.
     by_name: HashMap<GroupName, GroupLocation>,
-    /// Which DMX addrs already have a fixture patched in them.
+    /// DMX address allocations, indexed by `(universe, dmx_index)`.
     used_addrs: UsedAddrs,
+    /// The configs that built this patch.
+    configs: ShowPatchConfigs,
 }
 
 impl Patch {
@@ -119,6 +123,7 @@ impl Patch {
             by_id: HashMap::new(),
             by_name: HashMap::new(),
             used_addrs: Default::default(),
+            configs: ShowPatchConfigs::default(),
         }
     }
 
@@ -131,9 +136,9 @@ impl Patch {
     }
 
     /// Initialize a patch from a collection of groups.
-    pub fn patch_all(groups: &[FixtureGroupConfig]) -> Result<Self> {
+    pub fn patch_all(groups: ShowPatchConfigs) -> Result<Self> {
         let mut patch = Self::new();
-        for group in groups {
+        for group in groups.iter() {
             patch.patch(group).with_context(|| {
                 format!(
                     "patching {}{}",
@@ -146,6 +151,7 @@ impl Patch {
                 )
             })?;
         }
+        patch.configs = groups;
         Ok(patch)
     }
 
@@ -161,8 +167,8 @@ impl Patch {
     /// TODO: this approach will become problematic if we add control for any
     /// fixtures that require exclusive control of an external resource such as
     /// binding a socket.
-    pub fn repatch(&mut self, groups: &[FixtureGroupConfig]) -> Result<()> {
-        let mut new_patch = Self::patch_all(groups)?;
+    pub fn repatch(&mut self, groups: ShowPatchConfigs) -> Result<()> {
+        let mut new_patch = Self::patch_all(Arc::clone(&groups))?;
         // Drain old groups into an id-keyed map for O(1) reconciliation lookup.
         let mut old_by_id: HashMap<GroupId, FixtureGroup> = std::mem::take(&mut self.channels)
             .into_iter()
@@ -174,8 +180,23 @@ impl Patch {
                 group.reconfigure_from(old);
             }
         }
+        new_patch.configs = groups;
         *self = new_patch;
         Ok(())
+    }
+
+    /// The configs that built this patch.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "slice view; pending callers in later pieces")
+    )]
+    pub fn configs(&self) -> &[FixtureGroupConfig] {
+        &self.configs
+    }
+
+    /// A cheap-clone handle to the configs that built this patch.
+    pub fn configs_arc(&self) -> ShowPatchConfigs {
+        Arc::clone(&self.configs)
     }
 
     /// Patch a single fixture group config.
@@ -587,7 +608,7 @@ mod test {
         ",
         )?;
         assert_eq!(2, cfg.len());
-        let p = Patch::patch_all(&cfg)?;
+        let p = Patch::patch_all(cfg.into())?;
         let channel_pairs: Vec<_> = p.channels_with_ids().collect();
         assert_eq!(channel_pairs.len(), 1);
         assert_eq!("Color", channel_pairs[0].1.qualified_name().to_string());
@@ -647,8 +668,9 @@ mod test {
 
     fn assert_fail_patch(patch_yaml: &str, snippet: &str) {
         let Err(err) = Patch::patch_all(
-            &serde_yaml::from_str::<Vec<FixtureGroupConfig>>(patch_yaml)
-                .expect("invalid patch format"),
+            serde_yaml::from_str::<Vec<FixtureGroupConfig>>(patch_yaml)
+                .expect("invalid patch format")
+                .into(),
         ) else {
             panic!("patch didn't fail")
         };
@@ -819,7 +841,7 @@ mod test {
     - addr: 37
 ",
         )?;
-        let mut patch = Patch::patch_all(&cfg)?;
+        let mut patch = Patch::patch_all(cfg.clone().into())?;
 
         // Set distinct offsets in slot 0 so we can verify they survive the
         // repatch. Use the second slot too to make sure reconciliation
@@ -855,7 +877,7 @@ mod test {
 ",
         )?;
         grown_cfg[0].id = stable_id;
-        patch.repatch(&grown_cfg)?;
+        patch.repatch(grown_cfg.clone().into())?;
         let mut cfg = grown_cfg;
 
         // Existing offsets survived, new fixtures landed at zero, every
@@ -897,7 +919,7 @@ mod test {
         // selected_fixture (which was 3, now out of range) clamps to the
         // new max (2).
         cfg[0].patches.truncate(3);
-        patch.repatch(&cfg)?;
+        patch.repatch(cfg.clone().into())?;
 
         {
             let group = patch.iter().next().unwrap();
@@ -916,20 +938,57 @@ mod test {
         Ok(())
     }
 
+    /// `Patch::configs` returns the configs the patch was built from, and is
+    /// updated in lockstep with `repatch`.
+    #[test]
+    fn patch_retains_configs_across_repatch() -> Result<()> {
+        let initial = parse(
+            "
+- fixture: Dimmer
+  patches:
+    - addr: 1
+",
+        )?;
+        let mut patch = Patch::patch_all(initial.clone().into())?;
+        let initial_ids: Vec<GroupId> = patch.configs().iter().map(|c| c.id).collect();
+        let expected_initial_ids: Vec<GroupId> = initial.iter().map(|c| c.id).collect();
+        assert_eq!(initial_ids, expected_initial_ids);
+        assert_eq!(patch.configs().len(), initial.len());
+
+        let updated = parse(
+            "
+- fixture: Color
+  patches:
+    - addr: 1
+- fixture: Dimmer
+  group: Spare
+  patches:
+    - addr: 10
+",
+        )?;
+        patch.repatch(updated.clone().into())?;
+        let updated_ids: Vec<GroupId> = patch.configs().iter().map(|c| c.id).collect();
+        let expected_updated_ids: Vec<GroupId> = updated.iter().map(|c| c.id).collect();
+        assert_eq!(updated_ids, expected_updated_ids);
+        assert_eq!(patch.configs().len(), updated.len());
+        Ok(())
+    }
+
     /// Test that we can patch an instance of WLED.
     #[test]
     fn test_wled() {
         Patch::patch_all(
-            &parse(
+            parse(
                 "
 - fixture: Wled
   url: http://foo.bar.baz
   preset_count: 1
   patches:
-    - 
+    -
 ",
             )
-            .unwrap(),
+            .unwrap()
+            .into(),
         )
         .unwrap();
     }
@@ -956,7 +1015,7 @@ mod test {
     - addr: 12
         ",
         )?;
-        let mut patch = Patch::patch_all(&cfg)?;
+        let mut patch = Patch::patch_all(cfg.clone().into())?;
 
         let initial = render(&patch);
         // Should be all zeros, since everything is down.
@@ -974,7 +1033,7 @@ mod test {
 
         // Repatching with the same config should result in so fixture models
         // being updated.
-        patch.repatch(&cfg)?;
+        patch.repatch(cfg.clone().into())?;
 
         assert_eq!(render(&patch), twiddled);
 
@@ -983,7 +1042,7 @@ mod test {
         // controller knows it's the same group.
         cfg[0].group = Some(GroupName("NewColor".to_string()));
 
-        patch.repatch(&cfg)?;
+        patch.repatch(cfg.clone().into())?;
         let new_bufs = render(&patch);
         assert_eq!(2, new_bufs.len());
         assert_eq!(
@@ -994,7 +1053,7 @@ mod test {
 
         // Repatching with different patches should not force a new model.
         cfg[0].patches.truncate(1);
-        patch.repatch(&cfg)?;
+        patch.repatch(cfg.into())?;
 
         let new_bufs = render(&patch);
         // Should have different output since we have a different number of patches.

--- a/src/fixture/patch/mod.rs
+++ b/src/fixture/patch/mod.rs
@@ -219,11 +219,9 @@ impl Patch {
                 );
                 continue;
             };
-            if !group.supports_positioner() {
-                log::warn!("Loaded positioner for non-positionable group {id:?}; dropping");
-                continue;
+            if let Err(e) = group.install_positioner_presets(presets) {
+                log::warn!("Loaded positioner for group {id:?}: {e:#}; dropping");
             }
-            group.install_positioner_presets(presets);
         }
     }
 

--- a/src/gui_state.rs
+++ b/src/gui_state.rs
@@ -60,15 +60,24 @@ pub struct DmxDebugSnapshot {
 }
 
 bitflags::bitflags! {
-    /// GUI state domains that may need re-snapshotting after a control event.
+    /// Domains of show state that may have diverged from their downstream
+    /// representations (GUI snapshots, on-disk show file) and need to be
+    /// reconciled after a control event.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct GuiDirty: u8 {
+    pub struct StateDirty: u8 {
         const CLEAN       = 0b0000_0000;
         const MIDI_SLOTS  = 0b0000_0001;
         const CLOCK_STATE = 0b0000_0010;
         const DMX_PORTS   = 0b0000_0100;
         const AUDIO       = 0b0000_1000;
         const OSC_CLIENTS = 0b0001_0000;
+        const SHOW_FILE   = 0b0010_0000;
+        /// All GUI snapshot domains — every flag except [`Self::SHOW_FILE`].
+        const GUI_ALL = Self::MIDI_SLOTS.bits()
+            | Self::CLOCK_STATE.bits()
+            | Self::DMX_PORTS.bits()
+            | Self::AUDIO.bits()
+            | Self::OSC_CLIENTS.bits();
     }
 }
 

--- a/src/gui_state.rs
+++ b/src/gui_state.rs
@@ -9,9 +9,9 @@ use midi_harness::SlotStatus;
 use tunnels::{animation::Animation, audio::AudioSnapshot, clock_server::SharedClockData};
 use tunnels_lib::{notified::Notified, repaint::RepaintSignal};
 
-use crate::config::FixtureGroupConfig;
 use crate::dmx::{DmxBuffer, UniverseIdx};
 use crate::osc::OscClientId;
+use crate::show_file::ShowPatchConfigs;
 
 /// Snapshot of animation state for the visualizer panel.
 #[derive(Default)]
@@ -21,10 +21,10 @@ pub struct AnimationSnapshot {
     pub fixture_count: usize,
 }
 
-/// Snapshot of the current patch configuration for the GUI.
+/// Snapshot of the patch configuration.
 #[derive(Clone, Debug, Default)]
 pub struct PatchSnapshot {
-    pub groups: Vec<FixtureGroupConfig>,
+    pub groups: ShowPatchConfigs,
 }
 
 /// Port name from Display impl, used for both display and identity.

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ mod positioner;
 mod preview;
 mod show;
 mod show_file;
+mod show_saver;
 mod strobe;
 mod touchosc;
 mod ui_util;

--- a/src/positioner.rs
+++ b/src/positioner.rs
@@ -250,20 +250,26 @@ impl Positioner {
         emitter: &FixtureStateEmitter,
     ) -> Option<Result<()>> {
         if msg.control() == addr::POSITION_PRESET_SELECT.control {
-            Some(self.handle_preset_select(msg, &addr::POSITION_PRESET_SELECT, emitter))
+            Some(
+                self.handle_preset_select(msg, &addr::POSITION_PRESET_SELECT, emitter)
+                    .map(|_| ()),
+            )
         } else {
             None
         }
     }
 
     /// Handle a Positioner-tab OSC message (X/Y/Focus faders and bumps,
-    /// BumpStep, Prev/Next, Preset, Reset, ResetPreset). Returns `Err` for
-    /// an unrecognized address or a recognized-but-malformed message.
+    /// BumpStep, Prev/Next, Preset, Reset, ResetPreset). Returns `Ok(true)`
+    /// when the message mutated persistable content (a preset's offsets),
+    /// `Ok(false)` for editing-only mutations (selection, bump step) and
+    /// no-op releases. Returns `Err` for an unrecognized address or a
+    /// recognized-but-malformed message.
     pub fn control_osc_positioner_scoped(
         &mut self,
         msg: &OscControlMessage,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         match msg.control() {
             addr::X_FADER => self.handle_fader(msg, Axis::X, emitter),
             addr::Y_FADER => self.handle_fader(msg, Axis::Y, emitter),
@@ -329,10 +335,10 @@ impl Positioner {
         msg: &OscControlMessage,
         axis: Axis,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let val = msg.get_bipolar()?;
         let Some(offset) = self.selected_offset_mut()? else {
-            return Ok(());
+            return Ok(false);
         };
         match axis {
             Axis::X => offset.x = val,
@@ -340,7 +346,7 @@ impl Positioner {
             Axis::Focus => offset.focus = val,
         }
         self.emit_axis(axis, &emitter.scoped(addr::GROUP));
-        Ok(())
+        Ok(true)
     }
 
     fn handle_bump(
@@ -349,16 +355,16 @@ impl Positioner {
         axis: Axis,
         sign: Sign,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !msg.get_bool()? {
-            return Ok(());
+            return Ok(false);
         }
         let signed_delta = match sign {
             Sign::Plus => self.bump_step.magnitude(),
             Sign::Minus => -self.bump_step.magnitude(),
         };
         let Some(offset) = self.selected_offset_mut()? else {
-            return Ok(());
+            return Ok(false);
         };
         match axis {
             Axis::X => offset.x = BipolarFloat::new(offset.x.val() + signed_delta),
@@ -366,25 +372,25 @@ impl Positioner {
             Axis::Focus => offset.focus = BipolarFloat::new(offset.focus.val() + signed_delta),
         }
         self.emit_axis(axis, &emitter.scoped(addr::GROUP));
-        Ok(())
+        Ok(true)
     }
 
     fn handle_bump_step_select(
         &mut self,
         msg: &OscControlMessage,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let Some(index) = addr::BUMP_STEP_SELECT.parse_press(msg)? else {
-            return Ok(());
+            return Ok(false);
         };
         self.bump_step = match index {
             0 => BumpStep::Coarse,
             1 => BumpStep::Medium,
             2 => BumpStep::Fine,
-            _ => return Ok(()),
+            _ => return Ok(false),
         };
         self.emit_bump_step_radio(&emitter.scoped(addr::GROUP));
-        Ok(())
+        Ok(false)
     }
 
     fn handle_nudge_fixture(
@@ -392,9 +398,9 @@ impl Positioner {
         msg: &OscControlMessage,
         sign: Sign,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !msg.get_bool()? || self.fixture_count == 0 {
-            return Ok(());
+            return Ok(false);
         }
         let delta: isize = match sign {
             Sign::Plus => 1,
@@ -405,7 +411,7 @@ impl Positioner {
         let scoped = emitter.scoped(addr::GROUP);
         self.emit_fixture_label(&scoped);
         self.emit_selected_axes(&scoped);
-        Ok(())
+        Ok(false)
     }
 
     fn handle_preset_select(
@@ -413,12 +419,12 @@ impl Positioner {
         msg: &OscControlMessage,
         primitive: &RadioButton,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let Some(index) = primitive.parse_press(msg)? else {
-            return Ok(());
+            return Ok(false);
         };
         if index >= N_POSITIONER_SLOTS || self.active == index {
-            return Ok(());
+            return Ok(false);
         }
         self.active = index;
         // The per-group preset radio always reflects the change (it's the
@@ -429,32 +435,32 @@ impl Positioner {
         if emitter.channel().is_current() {
             self.emit_positioner_state(&emitter.scoped(addr::GROUP));
         }
-        Ok(())
+        Ok(false)
     }
 
     fn handle_reset_fixture(
         &mut self,
         msg: &OscControlMessage,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !msg.get_bool()? {
-            return Ok(());
+            return Ok(false);
         }
         let Some(offset) = self.selected_offset_mut()? else {
-            return Ok(());
+            return Ok(false);
         };
         *offset = PositionOffset::default();
         self.emit_selected_axes(&emitter.scoped(addr::GROUP));
-        Ok(())
+        Ok(true)
     }
 
     fn handle_reset_preset(
         &mut self,
         msg: &OscControlMessage,
         emitter: &FixtureStateEmitter,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !msg.get_bool()? {
-            return Ok(());
+            return Ok(false);
         }
         let active = self.active;
         let preset = self.presets.slots.get_mut(active).ok_or_else(|| {
@@ -467,7 +473,7 @@ impl Positioner {
             *off = PositionOffset::default();
         }
         self.emit_selected_axes(&emitter.scoped(addr::GROUP));
-        Ok(())
+        Ok(true)
     }
 
     /// Push the Positioner tab state. The emitter should be scoped to the

--- a/src/positioner.rs
+++ b/src/positioner.rs
@@ -8,6 +8,7 @@
 use anyhow::{Result, bail};
 use number::BipolarFloat;
 use rosc::OscType;
+use serde::{Deserialize, Serialize};
 
 use crate::osc::prelude::RadioButton;
 use crate::osc::{
@@ -25,9 +26,9 @@ pub const N_POSITIONER_AXES: usize = 3;
 /// Per-group positioner state: preset slots, the currently-active slot, and
 /// the editing state (selected fixture, bump granularity) shown on the
 /// Positioner tab.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Positioner {
-    presets: [PositionPreset; N_POSITIONER_SLOTS],
+    presets: PositionerPresets,
     /// Active preset slot (`0..N_POSITIONER_SLOTS`).
     active: usize,
     /// Index of the fixture being edited via the Positioner tab
@@ -40,8 +41,16 @@ pub struct Positioner {
     fixture_count: usize,
 }
 
+/// The persistable subset of a `Positioner`: the named preset slots.
+/// Editing UI state (active slot, selected fixture, bump step) is
+/// session-only and is not part of this type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PositionerPresets {
+    pub slots: [PositionPreset; N_POSITIONER_SLOTS],
+}
+
 /// One preset slot's data: a name and a per-fixture offset vector.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PositionPreset {
     /// Always populated. Defaults to `"Position {1..8}"` until the operator
     /// renames it via the desktop GUI.
@@ -54,7 +63,7 @@ pub struct PositionPreset {
 /// Per-fixture offset along the positioner's axes. The `focus` value is
 /// stored uniformly across all positionable groups but only contributes to
 /// render when the fixture type's [`PositionerAxes::focus`] is `Some`.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct PositionOffset {
     pub x: BipolarFloat,
     pub y: BipolarFloat,
@@ -77,7 +86,7 @@ pub struct PositionerAxes<T> {
 
 /// Step magnitude for the Positioner tab's bump buttons. Same step applies
 /// to X, Y, and Focus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BumpStep {
     /// ~0.05; broad, fast positioning.
     Coarse,
@@ -113,6 +122,42 @@ enum Sign {
     Minus,
 }
 
+impl std::ops::Index<usize> for PositionerPresets {
+    type Output = PositionPreset;
+    fn index(&self, i: usize) -> &PositionPreset {
+        &self.slots[i]
+    }
+}
+
+impl std::ops::IndexMut<usize> for PositionerPresets {
+    fn index_mut(&mut self, i: usize) -> &mut PositionPreset {
+        &mut self.slots[i]
+    }
+}
+
+impl PositionerPresets {
+    /// Build 8 default preset slots (named `"Position 1"` through
+    /// `"Position 8"`) sized for `fixture_count` fixtures.
+    pub fn default_for(fixture_count: usize) -> Self {
+        let slots = std::array::from_fn(|i| PositionPreset {
+            name: format!("Position {}", i + 1),
+            offsets: vec![PositionOffset::default(); fixture_count],
+        });
+        Self { slots }
+    }
+
+    /// Grow or shrink each preset's `offsets` vector to match a new
+    /// fixture count, preserving existing values where they overlap.
+    /// Extending pads with default (zero) offsets; truncating drops the
+    /// tail entries.
+    pub fn reconcile_to_fixture_count(&mut self, fixture_count: usize) {
+        for slot in &mut self.slots {
+            slot.offsets
+                .resize_with(fixture_count, PositionOffset::default);
+        }
+    }
+}
+
 impl Positioner {
     /// Build a fresh positioner for a group with `fixture_count` fixtures.
     ///
@@ -120,12 +165,8 @@ impl Positioner {
     /// 1"` through `"Position 8"`) and `fixture_count` zeroed offsets each.
     /// `active = 0`, `selected_fixture = 0`, `bump_step = Medium`.
     pub fn default_for(fixture_count: usize) -> Self {
-        let presets = std::array::from_fn(|i| PositionPreset {
-            name: format!("Position {}", i + 1),
-            offsets: vec![PositionOffset::default(); fixture_count],
-        });
         Self {
-            presets,
+            presets: PositionerPresets::default_for(fixture_count),
             active: 0,
             selected_fixture: 0,
             bump_step: BumpStep::Medium,
@@ -141,11 +182,7 @@ impl Positioner {
     /// Extending pads with default (zero) offsets; truncating drops the tail
     /// entries.
     pub fn reconcile_to_fixture_count(&mut self, new_count: usize) {
-        for preset in &mut self.presets {
-            preset
-                .offsets
-                .resize_with(new_count, PositionOffset::default);
-        }
+        self.presets.reconcile_to_fixture_count(new_count);
         self.fixture_count = new_count;
         // If a shrink dropped the previously-selected fixture, clamp.
         if self.selected_fixture >= new_count {
@@ -153,10 +190,24 @@ impl Positioner {
         }
     }
 
+    /// The persisted subset of this positioner's state (the named preset
+    /// slots).
+    pub fn presets(&self) -> &PositionerPresets {
+        &self.presets
+    }
+
+    /// Install loaded preset data, reconciling it to the current fixture
+    /// count first.
+    pub fn install_presets(&mut self, mut presets: PositionerPresets) {
+        presets.reconcile_to_fixture_count(self.fixture_count);
+        self.presets = presets;
+    }
+
     /// The offset for a given fixture in the currently-active preset, or
     /// `None` if `fixture_index` is out of range.
     pub fn offset_for_fixture(&self, fixture_index: usize) -> Option<PositionOffset> {
         self.presets
+            .slots
             .get(self.active)
             .and_then(|preset| preset.offsets.get(fixture_index))
             .copied()
@@ -168,7 +219,7 @@ impl Positioner {
     /// is out of range.
     pub fn rename_active_preset(&mut self, name: String, emitter: &FixtureStateEmitter) {
         let active = self.active;
-        let Some(preset) = self.presets.get_mut(active) else {
+        let Some(preset) = self.presets.slots.get_mut(active) else {
             return;
         };
         preset.name = name.clone();
@@ -251,7 +302,7 @@ impl Positioner {
         }
         let active = self.active;
         let selected_fixture = self.selected_fixture;
-        let preset = self.presets.get_mut(active).ok_or_else(|| {
+        let preset = self.presets.slots.get_mut(active).ok_or_else(|| {
             positioner_inconsistency(
                 "PO-001",
                 format!("active preset slot {active} out of range (max {N_POSITIONER_SLOTS})"),
@@ -406,7 +457,7 @@ impl Positioner {
             return Ok(());
         }
         let active = self.active;
-        let preset = self.presets.get_mut(active).ok_or_else(|| {
+        let preset = self.presets.slots.get_mut(active).ok_or_else(|| {
             positioner_inconsistency(
                 "PO-001",
                 format!("active preset slot {active} out of range (max {N_POSITIONER_SLOTS})"),
@@ -425,7 +476,7 @@ impl Positioner {
         self.emit_fixture_label(emitter);
         self.emit_selected_axes(emitter);
         addr::PRESET_SELECT.set(self.active, false, emitter);
-        addr::PRESET_LABELS.set(self.presets.iter().map(|p| p.name.clone()), emitter);
+        addr::PRESET_LABELS.set(self.presets.slots.iter().map(|p| p.name.clone()), emitter);
         self.emit_bump_step_radio(emitter);
     }
 
@@ -434,13 +485,14 @@ impl Positioner {
     /// [`FixtureStateEmitter`] that prefixes addresses with the group name).
     pub fn emit_per_group_state<E: EmitScopedOscMessage + ?Sized>(&self, emitter: &E) {
         addr::POSITION_PRESET_SELECT.set(self.active, false, emitter);
-        addr::POSITION_PRESET_LABEL.set(self.presets.iter().map(|p| p.name.clone()), emitter);
+        addr::POSITION_PRESET_LABEL.set(self.presets.slots.iter().map(|p| p.name.clone()), emitter);
     }
 
     /// Push the selected fixture's offset value along one axis.
     fn emit_axis<E: EmitScopedOscMessage + ?Sized>(&self, axis: Axis, emitter: &E) {
         let val = self
             .presets
+            .slots
             .get(self.active)
             .and_then(|preset| preset.offsets.get(self.selected_fixture))
             .map(|off| match axis {
@@ -526,15 +578,11 @@ mod tests {
             self.active
         }
 
-        pub fn presets(&self) -> &[PositionPreset; N_POSITIONER_SLOTS] {
-            &self.presets
-        }
-
         pub fn selected_fixture(&self) -> usize {
             self.selected_fixture
         }
 
-        pub fn presets_mut(&mut self) -> &mut [PositionPreset; N_POSITIONER_SLOTS] {
+        pub fn presets_mut(&mut self) -> &mut PositionerPresets {
             &mut self.presets
         }
 
@@ -544,23 +592,6 @@ mod tests {
 
         pub fn set_selected_fixture(&mut self, idx: usize) {
             self.selected_fixture = idx;
-        }
-    }
-
-    #[test]
-    fn default_for_seeds_named_presets_and_zero_offsets() {
-        let p = Positioner::default_for(4);
-        assert_eq!(p.active, 0);
-        assert_eq!(p.selected_fixture, 0);
-        assert_eq!(p.bump_step, BumpStep::Medium);
-        for (i, preset) in p.presets.iter().enumerate() {
-            assert_eq!(preset.name, format!("Position {}", i + 1));
-            assert_eq!(preset.offsets.len(), 4);
-            for off in &preset.offsets {
-                assert_eq!(off.x.val(), 0.0);
-                assert_eq!(off.y.val(), 0.0);
-                assert_eq!(off.focus.val(), 0.0);
-            }
         }
     }
 
@@ -591,22 +622,36 @@ mod tests {
         assert_eq!(p.presets[0].offsets[2].x.val(), 0.75);
         // selected_fixture was 4, but now max is 2.
         assert_eq!(p.selected_fixture, 2);
-    }
 
-    #[test]
-    fn reconcile_to_zero_clamps_selected_fixture_to_zero() {
-        let mut p = Positioner::default_for(3);
-        p.selected_fixture = 2;
+        // Shrinking to zero fixtures is its own edge case (empty offsets vec).
         p.reconcile_to_fixture_count(0);
         assert_eq!(p.presets[0].offsets.len(), 0);
         assert_eq!(p.selected_fixture, 0);
     }
 
     #[test]
-    fn bump_step_magnitudes() {
-        assert!((BumpStep::Coarse.magnitude() - 0.05).abs() < 1e-9);
-        assert!((BumpStep::Medium.magnitude() - 0.01).abs() < 1e-9);
-        assert!((BumpStep::Fine.magnitude() - 0.002).abs() < 1e-9);
+    fn positioner_yaml_round_trip() {
+        let mut p = Positioner::default_for(3);
+        p.presets_mut()[0].offsets[0].x = BipolarFloat::new(0.5);
+        p.presets_mut()[0].offsets[1].y = BipolarFloat::new(-0.25);
+        p.presets_mut()[2].offsets[2].focus = BipolarFloat::new(0.1);
+        p.presets_mut()[3].name = "Bar Spots".to_string();
+        p.set_active(2);
+        p.set_selected_fixture(1);
+        p.bump_step = BumpStep::Coarse;
+
+        // Only the persistable subset survives a save/load cycle. Editing
+        // UI state (active, selected_fixture, bump_step) is session-only.
+        let yaml = serde_yaml::to_string(p.presets()).unwrap();
+        let restored: PositionerPresets = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(restored[0].offsets[0].x.val(), 0.5);
+        assert_eq!(restored[0].offsets[1].y.val(), -0.25);
+        assert_eq!(restored[2].offsets[2].focus.val(), 0.1);
+        assert_eq!(restored[3].name, "Bar Spots");
+        for preset in &restored.slots {
+            assert_eq!(preset.offsets.len(), 3);
+        }
     }
 
     fn make_msg(addr: &str, arg: OscType) -> OscControlMessage {
@@ -700,21 +745,6 @@ mod tests {
     }
 
     #[test]
-    fn bump_down_clamps_at_negative_one() {
-        let mut p = Positioner::default_for(1);
-        p.bump_step = BumpStep::Coarse; // 0.05
-        p.presets[0].offsets[0].y = BipolarFloat::new(-0.99);
-
-        let name = crate::config::GroupName("Test".to_string());
-        let emitter = null_fixture_emitter(&name);
-        let msg = make_msg("/Positioner/YBumpDown", OscType::Float(1.0));
-        p.control_osc_positioner_scoped(&msg, &emitter).unwrap();
-
-        // -0.99 + -0.05 = -1.04, clamped to -1.0.
-        assert_eq!(p.presets[0].offsets[0].y.val(), -1.0);
-    }
-
-    #[test]
     fn bump_release_does_not_apply_delta() {
         // Bump buttons are momentary; the release (`0.0`) should be a no-op.
         let mut p = Positioner::default_for(1);
@@ -757,51 +787,5 @@ mod tests {
         let emitter = null_fixture_emitter(&name);
         let msg = make_msg("/Positioner/X", OscType::Float(0.5));
         p.control_osc_positioner_scoped(&msg, &emitter).unwrap();
-    }
-
-    #[test]
-    fn cleared_positioner_emit_clears_every_positioner_tab_control() {
-        let emitter = crate::osc::MockEmitter::new();
-        emit_cleared_positioner_state(&emitter);
-        let msgs = emitter.take();
-
-        // Indexed lookups by control name for clarity.
-        let by_addr: std::collections::HashMap<String, OscType> = msgs.into_iter().collect();
-
-        assert_eq!(
-            by_addr.get(addr::FIXTURE_LABEL),
-            Some(&OscType::String("—".to_string())),
-        );
-        assert_eq!(by_addr.get(addr::X_FADER), Some(&OscType::Float(0.0)));
-        assert_eq!(by_addr.get(addr::Y_FADER), Some(&OscType::Float(0.0)));
-        assert_eq!(by_addr.get(addr::FOCUS_FADER), Some(&OscType::Float(0.0)));
-
-        // Every preset radio button should be 0.0 (none selected).
-        for i in 1..=N_POSITIONER_SLOTS {
-            let addr = format!("{}/1/{}", addr::PRESET_SELECT.control, i);
-            assert_eq!(
-                by_addr.get(&addr),
-                Some(&OscType::Float(0.0)),
-                "preset radio {addr} not cleared",
-            );
-        }
-        // Every preset label slot should be cleared to the empty label "".
-        for i in 0..N_POSITIONER_SLOTS {
-            let addr = format!("{}/{}", addr::PRESET_LABELS.control, i);
-            assert_eq!(
-                by_addr.get(&addr),
-                Some(&OscType::String(String::new())),
-                "preset label {addr} not cleared",
-            );
-        }
-        // Every bump-step radio button should be 0.0.
-        for i in 1..=3 {
-            let addr = format!("{}/1/{}", addr::BUMP_STEP_SELECT.control, i);
-            assert_eq!(
-                by_addr.get(&addr),
-                Some(&OscType::Float(0.0)),
-                "bump-step radio {addr} not cleared",
-            );
-        }
     }
 }

--- a/src/positioner.rs
+++ b/src/positioner.rs
@@ -41,9 +41,7 @@ pub struct Positioner {
     fixture_count: usize,
 }
 
-/// The persistable subset of a `Positioner`: the named preset slots.
-/// Editing UI state (active slot, selected fixture, bump step) is
-/// session-only and is not part of this type.
+/// The named preset slots for a positionable group.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PositionerPresets {
     pub slots: [PositionPreset; N_POSITIONER_SLOTS],

--- a/src/show.rs
+++ b/src/show.rs
@@ -45,6 +45,9 @@ pub struct Show {
     envelope_streams_tx: Sender<EnvelopeStreams>,
     /// Last time a DMX output debug snapshot was pushed, for rate limiting.
     last_dmx_debug: Instant,
+    /// Path to the show file on disk, if one is bound. `None` disables
+    /// persistence.
+    show_file_path: Option<crate::show_file::ShowPath>,
 }
 
 const CONTROL_TIMEOUT: Duration = Duration::from_micros(500);
@@ -62,7 +65,7 @@ impl Show {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         patch: Patch,
-        initial_configs: Vec<crate::config::FixtureGroupConfig>,
+        show_file_path: Option<crate::show_file::ShowPath>,
         controller: Controller,
         dmx: Vec<DmxUniverse>,
         clocks: Clocks,
@@ -74,6 +77,7 @@ impl Show {
         let initial_channel = channels.current_channel();
         let animation_ui_state = AnimationUIState::new(initial_channel);
 
+        let initial_groups = patch.configs_arc();
         let mut show = Self {
             controller,
             dmx,
@@ -87,15 +91,29 @@ impl Show {
             gui_state,
             envelope_streams_tx,
             last_dmx_debug: Instant::now(),
+            show_file_path,
         };
         show.reconcile_submaster_wings()?;
         show.reconcile_clock_wing()?;
         show.refresh_ui();
         show.snapshot_gui_state(GuiDirty::all());
         show.gui_state.patch_snapshot.store(Arc::new(PatchSnapshot {
-            groups: initial_configs,
+            groups: initial_groups,
         }));
         Ok(show)
+    }
+
+    /// Persist the current show state to disk.
+    ///
+    /// No-op when no show file path is bound.
+    fn save_show(&self) -> Result<()> {
+        let Some(path) = self.show_file_path.as_ref() else {
+            return Ok(());
+        };
+        let show_file = crate::show_file::ShowFile {
+            patch: self.patch.configs_arc(),
+        };
+        crate::show_file::save(path, &show_file)
     }
 
     /// Run the show forever in the current thread.
@@ -175,10 +193,13 @@ impl Show {
     fn handle_meta_command(&mut self, cmd: MetaCommand) -> Result<GuiDirty> {
         match cmd {
             MetaCommand::Repatch(groups) => {
-                self.patch.repatch(&groups)?;
+                self.patch.repatch(Arc::clone(&groups))?;
                 self.gui_state
                     .patch_snapshot
                     .store(Arc::new(PatchSnapshot { groups }));
+                if let Err(e) = self.save_show() {
+                    error!("Show save failed: {e:#}");
+                }
                 self.post_repatch()
             }
             MetaCommand::RefreshUI => {
@@ -807,6 +828,7 @@ impl Show {
             gui_state,
             envelope_streams_tx,
             last_dmx_debug: Instant::now(),
+            show_file_path: None,
         };
         show.reconcile_submaster_wings().unwrap();
         show.reconcile_clock_wing().unwrap();
@@ -848,14 +870,14 @@ mod tests {
 
     fn show_from_yaml(yaml: &str) -> Show {
         let configs: Vec<crate::config::FixtureGroupConfig> = serde_yaml::from_str(yaml).unwrap();
-        let patch = Patch::patch_all(&configs).unwrap();
+        let patch = Patch::patch_all(configs.into()).unwrap();
         let (show, _send) = Show::test_new(patch);
         show
     }
 
     fn show_internal_from_yaml(yaml: &str) -> Show {
         let configs: Vec<crate::config::FixtureGroupConfig> = serde_yaml::from_str(yaml).unwrap();
-        let patch = Patch::patch_all(&configs).unwrap();
+        let patch = Patch::patch_all(configs.into()).unwrap();
         let (show, _send) = Show::test_new_internal(patch);
         show
     }
@@ -933,7 +955,7 @@ mod tests {
         yaml: &str,
     ) -> (Show, OscCapture, std::sync::mpsc::Sender<ControlMessage>) {
         let configs: Vec<crate::config::FixtureGroupConfig> = serde_yaml::from_str(yaml).unwrap();
-        let patch = Patch::patch_all(&configs).unwrap();
+        let patch = Patch::patch_all(configs.into()).unwrap();
         let (show, send, rx) = Show::test_new_with_osc_capture(patch);
         (show, OscCapture::new(rx), send)
     }
@@ -1129,7 +1151,7 @@ mod tests {
 
     fn repatch_from_yaml(show: &mut Show, yaml: &str) {
         let configs: Vec<crate::config::FixtureGroupConfig> = serde_yaml::from_str(yaml).unwrap();
-        show.handle_meta_command(MetaCommand::Repatch(configs))
+        show.handle_meta_command(MetaCommand::Repatch(configs.into()))
             .unwrap();
     }
 

--- a/src/show.rs
+++ b/src/show.rs
@@ -78,7 +78,7 @@ impl Show {
         let initial_channel = channels.current_channel();
         let animation_ui_state = AnimationUIState::new(initial_channel);
 
-        let initial_groups = patch.configs_arc();
+        let initial_groups = patch.configs();
         let mut show = Self {
             controller,
             dmx,
@@ -99,6 +99,10 @@ impl Show {
         show.reconcile_clock_wing()?;
         show.refresh_ui();
         show.snapshot_state(StateDirty::GUI_ALL);
+        // Initial save: surfaces a bad path early and normalizes the
+        // on-disk file to the current schema if the load reconciled
+        // anything.
+        show.save_show();
         show.gui_state.patch_snapshot.store(Arc::new(PatchSnapshot {
             groups: initial_groups,
         }));
@@ -112,7 +116,7 @@ impl Show {
             return;
         };
         let file = crate::show_file::ShowFile {
-            patch: self.patch.configs_arc(),
+            patch: self.patch.configs(),
             positioners: self
                 .patch
                 .iter()

--- a/src/show.rs
+++ b/src/show.rs
@@ -114,6 +114,11 @@ impl Show {
         };
         let file = crate::show_file::ShowFile {
             patch: self.patch.configs_arc(),
+            positioners: self
+                .patch
+                .iter()
+                .filter_map(|g| g.positioner().map(|p| (g.id(), p.presets().clone())))
+                .collect(),
         };
         self.saver.submit(path.clone(), file);
     }
@@ -304,6 +309,7 @@ impl Show {
                     ),
                 );
                 positioner.rename_active_preset(name, &emitter);
+                self.save_show();
                 Ok(GuiDirty::CLEAN)
             }
         }
@@ -498,6 +504,7 @@ impl Show {
                     let fixture_emitter =
                         crate::osc::FixtureStateEmitter::new(name, channel_emitter);
                     positioner.control_osc_positioner_scoped(msg, &fixture_emitter)?;
+                    self.save_show();
                 }
                 Ok(GuiDirty::CLEAN)
             }
@@ -1453,43 +1460,6 @@ mod tests {
             }
         }
 
-        /// Tap `/IWashLed/PositionPresetSelect/1/5` (per-group dispatch)
-        /// while IWashLed is the current channel. Expect: `active` flips
-        /// to slot 4, and both the per-group radio echo AND the channel-
-        /// scoped tab refresh happen.
-        #[test]
-        fn per_group_preset_tap_on_current_channel_cross_emits() {
-            let (mut show, capture, _send) = show_with_capture_from_yaml(ONE_IWASH);
-            capture.drain();
-
-            fire_press(&mut show, "/IWashLed/PositionPresetSelect/1/5").unwrap();
-            let emits = capture.drain_by_addr();
-
-            let channel = show.channels_for_test().current_channel().unwrap();
-            let positioner = show
-                .patch_for_test()
-                .channel_group(channel)
-                .unwrap()
-                .positioner()
-                .unwrap();
-            assert_eq!(positioner.active(), 4);
-
-            // Per-group radio echoed.
-            assert_eq!(
-                emits.get("/IWashLed/PositionPresetSelect/1/5"),
-                Some(&OscType::Float(1.0)),
-            );
-            // Positioner tab refreshed (Preset radio + a label slot as proof).
-            assert_eq!(
-                emits.get("/Positioner/Preset/1/5"),
-                Some(&OscType::Float(1.0)),
-            );
-            assert_eq!(
-                emits.get("/Positioner/PresetLabel/4"),
-                Some(&OscType::String("Position 5".to_string())),
-            );
-        }
-
         /// Tap `/IWashBack/PositionPresetSelect/1/5` while IWashFront IS the
         /// current channel. Expect: IWashBack's state mutates, IWashFront's
         /// doesn't, and the Positioner tab is *not*
@@ -1732,83 +1702,6 @@ mod tests {
             fire(&mut show, "/Positioner/Focus", OscType::Float(0.1)).unwrap();
             let emits = capture.drain_by_addr();
             assert_positioner_tab_emits(&emits, &["/Positioner/Focus"]);
-        }
-
-        /// Bumping one axis must push only that axis's fader.
-        #[test]
-        fn bump_emits_only_target_axis() {
-            let (mut show, capture, _send) = show_with_capture_from_yaml(ONE_IWASH);
-            capture.drain();
-
-            fire_press(&mut show, "/Positioner/XBumpUp").unwrap();
-            let emits = capture.drain_by_addr();
-            assert_positioner_tab_emits(&emits, &["/Positioner/X"]);
-
-            fire_press(&mut show, "/Positioner/YBumpDown").unwrap();
-            let emits = capture.drain_by_addr();
-            assert_positioner_tab_emits(&emits, &["/Positioner/Y"]);
-
-            fire_press(&mut show, "/Positioner/FocusBumpUp").unwrap();
-            let emits = capture.drain_by_addr();
-            assert_positioner_tab_emits(&emits, &["/Positioner/Focus"]);
-        }
-
-        /// Changing the bump-step magnitude must push only the BumpStep
-        /// radio's 3 button-state messages.
-        #[test]
-        fn bump_step_emits_only_bump_step_radio() {
-            let (mut show, capture, _send) = show_with_capture_from_yaml(ONE_IWASH);
-            capture.drain();
-
-            // Switch from default Medium (slot 2) to Coarse (slot 1).
-            fire_press(&mut show, "/Positioner/BumpStep/1/1").unwrap();
-            let emits = capture.drain_by_addr();
-            assert_positioner_tab_emits(
-                &emits,
-                &[
-                    "/Positioner/BumpStep/1/1",
-                    "/Positioner/BumpStep/1/2",
-                    "/Positioner/BumpStep/1/3",
-                ],
-            );
-        }
-
-        /// Prev/Next selected fixture must push FixtureLabel and the three
-        /// axis faders, but not the preset radio or bump-step.
-        #[test]
-        fn nudge_fixture_emits_only_fixture_label_and_axes() {
-            let (mut show, capture, _send) = show_with_capture_from_yaml(ONE_IWASH);
-            capture.drain();
-
-            fire_press(&mut show, "/Positioner/Next").unwrap();
-            let emits = capture.drain_by_addr();
-            assert_positioner_tab_emits(
-                &emits,
-                &[
-                    "/Positioner/FixtureLabel",
-                    "/Positioner/X",
-                    "/Positioner/Y",
-                    "/Positioner/Focus",
-                ],
-            );
-        }
-
-        /// Reset (single fixture) zeroes the selected fixture's offsets, so
-        /// the three faders snap to zero. Nothing else changes.
-        #[test]
-        fn reset_fixture_emits_only_axes() {
-            let (mut show, capture, _send) = show_with_capture_from_yaml(ONE_IWASH);
-            // Stash some non-zero values so the snap-to-zero is observable.
-            fire(&mut show, "/Positioner/X", OscType::Float(0.5)).unwrap();
-            fire(&mut show, "/Positioner/Y", OscType::Float(-0.25)).unwrap();
-            capture.drain();
-
-            fire_press(&mut show, "/Positioner/Reset").unwrap();
-            let emits = capture.drain_by_addr();
-            assert_positioner_tab_emits(
-                &emits,
-                &["/Positioner/X", "/Positioner/Y", "/Positioner/Focus"],
-            );
         }
 
         /// Renaming a preset slot must push only that one slot's label on

--- a/src/show.rs
+++ b/src/show.rs
@@ -15,9 +15,8 @@ use crate::{
     },
     gui_state::{
         AnimationSnapshot, DMX_DEBUG_NOT_WATCHING, DmxDebugSnapshot, DmxPortInfo, DmxPortStatus,
-        PatchSnapshot,
+        PatchSnapshot, SharedGuiState, StateDirty,
     },
-    gui_state::{GuiDirty, SharedGuiState},
     master::MasterControls,
     midi::{EmitMidiChannelMessage, MidiControlMessage, MidiHandler},
     osc::{OscControlMessage, ScopedControlEmitter},
@@ -99,7 +98,7 @@ impl Show {
         show.reconcile_submaster_wings()?;
         show.reconcile_clock_wing()?;
         show.refresh_ui();
-        show.snapshot_gui_state(GuiDirty::all());
+        show.snapshot_state(StateDirty::GUI_ALL);
         show.gui_state.patch_snapshot.store(Arc::new(PatchSnapshot {
             groups: initial_groups,
         }));
@@ -132,7 +131,7 @@ impl Show {
             match self.control(CONTROL_TIMEOUT) {
                 Ok(dirty) => {
                     if !dirty.is_empty() {
-                        self.snapshot_gui_state(dirty);
+                        self.snapshot_state(dirty);
                     }
                 }
                 Err(err) => error!("A control error occurred: {err:#}."),
@@ -168,11 +167,11 @@ impl Show {
     /// Handle at most one control message.
     ///
     /// Wait for the provided duration for a message to appear.
-    fn control(&mut self, timeout: Duration) -> Result<GuiDirty> {
+    fn control(&mut self, timeout: Duration) -> Result<StateDirty> {
         let msg = match self.controller.recv(timeout)? {
             Some(m) => m,
             None => {
-                return Ok(GuiDirty::CLEAN);
+                return Ok(StateDirty::CLEAN);
             }
         };
 
@@ -182,7 +181,7 @@ impl Show {
                 if needs_ui_refresh {
                     self.refresh_ui();
                 }
-                Ok(GuiDirty::MIDI_SLOTS)
+                Ok(StateDirty::MIDI_SLOTS)
             }
             ControlMessage::Midi(msg) => self.handle_midi_message(&msg),
             ControlMessage::Osc(msg) => self.handle_osc_message(&msg),
@@ -197,30 +196,29 @@ impl Show {
     }
 
     /// Handle a meta-command.
-    fn handle_meta_command(&mut self, cmd: MetaCommand) -> Result<GuiDirty> {
+    fn handle_meta_command(&mut self, cmd: MetaCommand) -> Result<StateDirty> {
         match cmd {
             MetaCommand::Repatch(groups) => {
                 self.patch.repatch(Arc::clone(&groups))?;
                 self.gui_state
                     .patch_snapshot
                     .store(Arc::new(PatchSnapshot { groups }));
-                self.save_show();
-                self.post_repatch()
+                self.post_repatch().map(|d| d | StateDirty::SHOW_FILE)
             }
             MetaCommand::RefreshUI => {
                 self.refresh_ui();
-                Ok(GuiDirty::all())
+                Ok(StateDirty::GUI_ALL)
             }
             MetaCommand::ResetAllAnimations => {
                 for group in self.patch.iter_mut() {
                     group.reset_animations();
                 }
                 self.refresh_ui();
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             MetaCommand::AssignDmxPort { universe, port } => {
                 assign_dmx_port(&mut self.dmx, universe, port)?;
-                Ok(GuiDirty::DMX_PORTS)
+                Ok(StateDirty::DMX_PORTS)
             }
             MetaCommand::SetDmxPortFramerate {
                 universe,
@@ -233,12 +231,12 @@ impl Show {
                 univ.port
                     .set_framerate(framerate)
                     .with_context(|| format!("set framerate on port {}", univ.port))?;
-                Ok(GuiDirty::DMX_PORTS)
+                Ok(StateDirty::DMX_PORTS)
             }
             MetaCommand::ClearMidiDevice { slot_name } => {
                 self.controller.clear_midi_device(&slot_name)?;
                 self.refresh_ui();
-                Ok(GuiDirty::MIDI_SLOTS)
+                Ok(StateDirty::MIDI_SLOTS)
             }
             MetaCommand::ConnectMidiPort {
                 slot_name,
@@ -248,34 +246,34 @@ impl Show {
                 self.controller
                     .connect_midi_port(&slot_name, device_id, kind)?;
                 self.refresh_ui();
-                Ok(GuiDirty::MIDI_SLOTS)
+                Ok(StateDirty::MIDI_SLOTS)
             }
             MetaCommand::UseClockService(service) => {
                 self.clocks = Clocks::Service(service);
                 self.reconcile_clock_wing()?;
                 self.refresh_ui();
-                Ok(GuiDirty::MIDI_SLOTS | GuiDirty::CLOCK_STATE)
+                Ok(StateDirty::MIDI_SLOTS | StateDirty::CLOCK_STATE)
             }
             MetaCommand::UseInternalClocks(device_name) => {
                 self.clocks = Clocks::internal(device_name, self.envelope_streams_tx.clone())?;
                 self.reconcile_clock_wing()?;
                 self.refresh_ui();
-                Ok(GuiDirty::MIDI_SLOTS | GuiDirty::CLOCK_STATE | GuiDirty::AUDIO)
+                Ok(StateDirty::MIDI_SLOTS | StateDirty::CLOCK_STATE | StateDirty::AUDIO)
             }
             MetaCommand::RegisterOscClient(client_id) => {
                 println!("Registering new OSC client at {client_id}.");
                 self.controller.register_osc_client(client_id);
                 self.refresh_ui();
-                Ok(GuiDirty::OSC_CLIENTS)
+                Ok(StateDirty::OSC_CLIENTS)
             }
             MetaCommand::DropOscClient(client_id) => {
                 println!("Deregistering OSC client at {client_id}.");
                 self.controller.deregister_osc_client(client_id);
-                Ok(GuiDirty::OSC_CLIENTS)
+                Ok(StateDirty::OSC_CLIENTS)
             }
             MetaCommand::SwapOscSocket(socket) => {
                 self.controller.swap_osc_socket(socket);
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             MetaCommand::SetMasterStrobeChannel(enable) => {
                 if enable {
@@ -286,19 +284,19 @@ impl Show {
                 } else {
                     self.set_master_strobe_channel(None);
                 }
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             MetaCommand::AudioControl(msg) => {
                 Ok(self.clocks.control_audio(msg, &mut self.controller))
             }
             MetaCommand::RenamePositionerPreset(name) => {
                 let Some(channel) = self.channels.current_channel() else {
-                    return Ok(GuiDirty::CLEAN);
+                    return Ok(StateDirty::CLEAN);
                 };
                 let group = self.patch.channel_group_mut(channel)?;
                 let (group_name, positioner) = group.split_for_positioner_dispatch();
                 let Some(positioner) = positioner else {
-                    return Ok(GuiDirty::CLEAN);
+                    return Ok(StateDirty::CLEAN);
                 };
                 let sender = self.controller.sender_with_metadata(None);
                 let emitter = crate::osc::FixtureStateEmitter::new(
@@ -309,14 +307,13 @@ impl Show {
                     ),
                 );
                 positioner.rename_active_preset(name, &emitter);
-                self.save_show();
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::SHOW_FILE)
             }
         }
     }
 
     /// Shared post-repatch logic: clear channels, reconcile wings, resize DMX buffers.
-    fn post_repatch(&mut self) -> Result<GuiDirty> {
+    fn post_repatch(&mut self) -> Result<StateDirty> {
         let sender = self.controller.sender_with_metadata(None);
         sender.emit_midi_channel_message(&crate::channel::StateChange::Clear);
         Channels::emit_osc_state_change(
@@ -345,7 +342,7 @@ impl Show {
         for univ in &mut self.dmx {
             univ.buffer.fill(0);
         }
-        Ok(GuiDirty::MIDI_SLOTS | GuiDirty::DMX_PORTS)
+        Ok(StateDirty::MIDI_SLOTS | StateDirty::DMX_PORTS)
     }
 
     /// Returns `Some(channel_index)` if the last wing fader is available for
@@ -383,26 +380,26 @@ impl Show {
     }
 
     /// Handle a single MIDI control message.
-    fn handle_midi_message(&mut self, msg: &MidiControlMessage) -> Result<GuiDirty> {
+    fn handle_midi_message(&mut self, msg: &MidiControlMessage) -> Result<StateDirty> {
         let sender = self.controller.sender_with_metadata(None);
         let Some(show_ctrl_msg) = msg.device.interpret(&msg.event) else {
-            return Ok(GuiDirty::CLEAN);
+            return Ok(StateDirty::CLEAN);
         };
         match show_ctrl_msg {
             ShowControlMessage::Channel(msg) => {
                 self.handle_channel_message(&msg)?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             ShowControlMessage::Clock(msg) => {
                 self.clocks.control_clock(msg, sender.controller);
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             ShowControlMessage::Audio(msg) => {
                 Ok(self.clocks.control_audio(msg, &mut self.controller))
             }
             ShowControlMessage::Master(msg) => {
                 self.master_controls.control(&msg, &sender);
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             ShowControlMessage::Animation(msg) => {
                 let Some(channel) = self.channels.current_channel() else {
@@ -420,7 +417,7 @@ impl Show {
                         emitter: &sender,
                     },
                 )?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             ShowControlMessage::ColorOrgan(msg) => {
                 // FIXME: this is really janky and has no way to route messages.
@@ -430,13 +427,13 @@ impl Show {
                     };
                     color_organ.control(msg.clone(), &IgnoreEmitter);
                 }
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
         }
     }
 
     /// Handle a single OSC message.
-    fn handle_osc_message(&mut self, msg: &OscControlMessage) -> Result<GuiDirty> {
+    fn handle_osc_message(&mut self, msg: &OscControlMessage) -> Result<StateDirty> {
         let sender = self.controller.sender_with_metadata(Some(&msg.client_id));
 
         match msg.group() {
@@ -444,12 +441,12 @@ impl Show {
                 if let Some(cmd) = meta_command_from_osc(msg)? {
                     self.handle_meta_command(cmd)
                 } else {
-                    Ok(GuiDirty::CLEAN)
+                    Ok(StateDirty::CLEAN)
                 }
             }
             crate::master::GROUP => {
                 self.master_controls.control_osc(msg, &sender)?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             crate::osc::channels::GROUP => {
                 self.channels.control_osc(
@@ -458,7 +455,7 @@ impl Show {
                     &self.animation_ui_state,
                     &sender,
                 )?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             crate::osc::animation::GROUP => {
                 let Some(channel) = self.channels.current_channel() else {
@@ -476,12 +473,12 @@ impl Show {
                         emitter: &sender,
                     },
                 )?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             crate::osc::audio::GROUP => self.clocks.control_audio_osc(msg, &mut self.controller),
             crate::osc::clock::GROUP => {
                 self.clocks.control_clock_osc(msg, &mut self.controller)?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             crate::osc::positioner::GROUP => {
                 // /Positioner/... dispatch. Look up the current channel's
@@ -489,7 +486,7 @@ impl Show {
                 // a `ChannelBinding::Current` emitter (we know we're in
                 // current-channel context by construction).
                 let Some(channel) = self.channels.current_channel() else {
-                    return Ok(GuiDirty::CLEAN);
+                    return Ok(StateDirty::CLEAN);
                 };
                 let group = self.patch.channel_group_mut(channel)?;
                 let channel_emitter = ChannelStateEmitter::new(
@@ -503,10 +500,11 @@ impl Show {
                 if let Some(positioner) = positioner {
                     let fixture_emitter =
                         crate::osc::FixtureStateEmitter::new(name, channel_emitter);
-                    positioner.control_osc_positioner_scoped(msg, &fixture_emitter)?;
-                    self.save_show();
+                    if positioner.control_osc_positioner_scoped(msg, &fixture_emitter)? {
+                        return Ok(StateDirty::SHOW_FILE);
+                    }
                 }
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
             // Assume any other control group is referring to a fixture group.
             fixture_group => {
@@ -516,29 +514,34 @@ impl Show {
                     self.channels.current_channel(),
                 );
                 group.control(msg, ChannelStateEmitter::new(binding, &sender))?;
-                Ok(GuiDirty::CLEAN)
+                Ok(StateDirty::CLEAN)
             }
         }
     }
 
-    /// Selectively snapshot GUI state for the dirty domains.
-    fn snapshot_gui_state(&self, dirty: GuiDirty) {
-        if dirty.contains(GuiDirty::MIDI_SLOTS) {
+    /// Drive save and GUI snapshot reactions to dirty state. For each set
+    /// flag, performs the corresponding downstream reconciliation: saving
+    /// the show file to disk or refreshing the matching GUI snapshot.
+    fn snapshot_state(&self, dirty: StateDirty) {
+        if dirty.contains(StateDirty::SHOW_FILE) {
+            self.save_show();
+        }
+        if dirty.contains(StateDirty::MIDI_SLOTS) {
             self.gui_state
                 .midi_slots
                 .store(self.controller.midi_slot_statuses());
         }
-        if dirty.contains(GuiDirty::OSC_CLIENTS) {
+        if dirty.contains(StateDirty::OSC_CLIENTS) {
             self.gui_state
                 .osc_clients
                 .store(self.controller.osc_client_ids());
         }
-        if dirty.contains(GuiDirty::CLOCK_STATE) {
+        if dirty.contains(StateDirty::CLOCK_STATE) {
             self.gui_state
                 .clock_status
                 .store(Arc::new(self.clocks.status()));
         }
-        if dirty.contains(GuiDirty::DMX_PORTS) {
+        if dirty.contains(StateDirty::DMX_PORTS) {
             self.gui_state
                 .dmx_port_status
                 .store(Arc::new(DmxPortStatus {
@@ -552,7 +555,7 @@ impl Show {
                         .collect(),
                 }));
         }
-        if dirty.contains(GuiDirty::AUDIO)
+        if dirty.contains(StateDirty::AUDIO)
             && let Some(snap) = self.clocks.audio_snapshot()
         {
             self.gui_state.audio_state.store(snap);
@@ -903,7 +906,7 @@ mod tests {
     //
     // 3. `fire` / `fire_press` — build an `OscControlMessage` from a string
     //    address + arg, dispatch it through `Show::handle_osc_message`, and
-    //    return the resulting `GuiDirty`.
+    //    return the resulting `StateDirty`.
     //
     // Typical flow:
     //
@@ -969,8 +972,8 @@ mod tests {
     }
 
     /// Build and dispatch an OSC message at `addr` carrying a single `arg`,
-    /// returning the resulting `GuiDirty`.
-    fn fire(show: &mut Show, addr: &str, arg: OscType) -> Result<GuiDirty> {
+    /// returning the resulting `StateDirty`.
+    fn fire(show: &mut Show, addr: &str, arg: OscType) -> Result<StateDirty> {
         let msg = crate::osc::OscControlMessage::new(
             OscMessage {
                 addr: addr.to_string(),
@@ -983,7 +986,7 @@ mod tests {
     }
 
     /// Convenience for momentary button presses — fires `Float(1.0)`.
-    fn fire_press(show: &mut Show, addr: &str) -> Result<GuiDirty> {
+    fn fire_press(show: &mut Show, addr: &str) -> Result<StateDirty> {
         fire(show, addr, OscType::Float(1.0))
     }
 
@@ -997,7 +1000,7 @@ mod tests {
             ))
             .expect("audio control should not error");
 
-        assert_eq!(dirty, GuiDirty::AUDIO);
+        assert_eq!(dirty, StateDirty::AUDIO);
     }
 
     #[test]
@@ -1011,7 +1014,7 @@ mod tests {
 
         assert_eq!(
             dirty,
-            GuiDirty::MIDI_SLOTS | GuiDirty::CLOCK_STATE | GuiDirty::AUDIO,
+            StateDirty::MIDI_SLOTS | StateDirty::CLOCK_STATE | StateDirty::AUDIO,
         );
     }
 
@@ -1023,15 +1026,15 @@ mod tests {
         let dirty = show
             .handle_meta_command(MetaCommand::RegisterOscClient(client))
             .expect("register should not error");
-        assert_eq!(dirty, GuiDirty::OSC_CLIENTS);
-        show.snapshot_gui_state(dirty);
+        assert_eq!(dirty, StateDirty::OSC_CLIENTS);
+        show.snapshot_state(dirty);
         assert!(show.gui_state.osc_clients.load().contains(&client));
 
         let dirty = show
             .handle_meta_command(MetaCommand::DropOscClient(client))
             .expect("drop should not error");
-        assert_eq!(dirty, GuiDirty::OSC_CLIENTS);
-        show.snapshot_gui_state(dirty);
+        assert_eq!(dirty, StateDirty::OSC_CLIENTS);
+        show.snapshot_state(dirty);
         assert!(!show.gui_state.osc_clients.load().contains(&client));
     }
 
@@ -1100,10 +1103,10 @@ mod tests {
                 framerate: 30,
             })
             .unwrap();
-        assert_eq!(dirty, GuiDirty::DMX_PORTS);
+        assert_eq!(dirty, StateDirty::DMX_PORTS);
         assert_eq!(show.dmx[0].port.get_framerate(), Some(30));
 
-        show.snapshot_gui_state(GuiDirty::DMX_PORTS);
+        show.snapshot_state(StateDirty::DMX_PORTS);
         let snapshot = show.gui_state.dmx_port_status.load();
         assert_eq!(snapshot.ports[0].framerate, Some(30));
         assert_eq!(snapshot.ports[1].framerate, None);

--- a/src/show.rs
+++ b/src/show.rs
@@ -48,6 +48,8 @@ pub struct Show {
     /// Path to the show file on disk, if one is bound. `None` disables
     /// persistence.
     show_file_path: Option<crate::show_file::ShowPath>,
+    /// Worker that performs the actual file write off the show thread.
+    saver: crate::show_saver::ShowSaver,
 }
 
 const CONTROL_TIMEOUT: Duration = Duration::from_micros(500);
@@ -92,6 +94,7 @@ impl Show {
             envelope_streams_tx,
             last_dmx_debug: Instant::now(),
             show_file_path,
+            saver: crate::show_saver::ShowSaver::spawn(),
         };
         show.reconcile_submaster_wings()?;
         show.reconcile_clock_wing()?;
@@ -103,17 +106,16 @@ impl Show {
         Ok(show)
     }
 
-    /// Persist the current show state to disk.
-    ///
-    /// No-op when no show file path is bound.
-    fn save_show(&self) -> Result<()> {
+    /// Submit a snapshot of the current show state for persistence. No-op
+    /// when no show file path is bound.
+    fn save_show(&self) {
         let Some(path) = self.show_file_path.as_ref() else {
-            return Ok(());
+            return;
         };
-        let show_file = crate::show_file::ShowFile {
+        let file = crate::show_file::ShowFile {
             patch: self.patch.configs_arc(),
         };
-        crate::show_file::save(path, &show_file)
+        self.saver.submit(path.clone(), file);
     }
 
     /// Run the show forever in the current thread.
@@ -197,9 +199,7 @@ impl Show {
                 self.gui_state
                     .patch_snapshot
                     .store(Arc::new(PatchSnapshot { groups }));
-                if let Err(e) = self.save_show() {
-                    error!("Show save failed: {e:#}");
-                }
+                self.save_show();
                 self.post_repatch()
             }
             MetaCommand::RefreshUI => {
@@ -829,6 +829,7 @@ impl Show {
             envelope_streams_tx,
             last_dmx_debug: Instant::now(),
             show_file_path: None,
+            saver: crate::show_saver::ShowSaver::spawn(),
         };
         show.reconcile_submaster_wings().unwrap();
         show.reconcile_clock_wing().unwrap();

--- a/src/show_file.rs
+++ b/src/show_file.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -18,12 +19,42 @@ pub const DEFAULT_FILE_NAME: &str = "show.cobra";
 /// Extension used for the temporary file during atomic saves.
 const TMP_EXTENSION: &str = "cobra.tmp";
 
+/// The path to a show file on disk.
+///
+/// Wraps an `Arc<Path>` so the path can be cloned across thread boundaries with
+/// only a refcount bump rather than a buffer reallocation. `Deref<Target = Path>`
+/// lets it act as a `&Path` for any `Path`-shaped API (e.g. `show_file::save`).
+#[derive(Clone)]
+pub struct ShowPath(Arc<Path>);
+
+impl ShowPath {
+    pub fn new(path: impl Into<Arc<Path>>) -> Self {
+        Self(path.into())
+    }
+}
+
+impl std::ops::Deref for ShowPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+/// An immutable, cheap-clone handle to the show's patch configs.
+///
+/// Backed by `Arc<[T]>` so clones across thread boundaries cost a refcount
+/// bump rather than reallocating the underlying slice. The configs themselves
+/// are never mutated in place — repatch replaces the whole slice — so a
+/// shared, immutable view is the natural shape.
+pub type ShowPatchConfigs = Arc<[FixtureGroupConfig]>;
+
 /// On-disk format for a Cobra Commander show file (`.cobra`).
 ///
 /// Wraps the patch data so we can add sibling fields in the future.
 #[derive(Serialize, Deserialize)]
 pub struct ShowFile {
-    pub patch: Vec<FixtureGroupConfig>,
+    pub patch: ShowPatchConfigs,
 }
 
 /// Load a show file from disk.

--- a/src/show_file.rs
+++ b/src/show_file.rs
@@ -52,7 +52,7 @@ impl std::ops::Deref for ShowPath {
 pub type ShowPatchConfigs = Arc<[FixtureGroupConfig]>;
 
 /// On-disk format for a Cobra Commander show file (`.cobra`).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ShowFile {
     pub patch: ShowPatchConfigs,
     #[serde(default)]

--- a/src/show_file.rs
+++ b/src/show_file.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -5,7 +6,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::config::FixtureGroupConfig;
+use crate::config::{FixtureGroupConfig, GroupId};
+use crate::positioner::PositionerPresets;
 
 /// File extension for show files (without the leading dot).
 pub const EXTENSION: &str = "cobra";
@@ -50,11 +52,11 @@ impl std::ops::Deref for ShowPath {
 pub type ShowPatchConfigs = Arc<[FixtureGroupConfig]>;
 
 /// On-disk format for a Cobra Commander show file (`.cobra`).
-///
-/// Wraps the patch data so we can add sibling fields in the future.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ShowFile {
     pub patch: ShowPatchConfigs,
+    #[serde(default)]
+    pub positioners: HashMap<GroupId, PositionerPresets>,
 }
 
 /// Load a show file from disk.

--- a/src/show_saver.rs
+++ b/src/show_saver.rs
@@ -1,7 +1,10 @@
-use std::sync::mpsc;
+use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::show_file::{self, ShowFile, ShowPath};
+
+const SAVE_THROTTLE: Duration = Duration::from_millis(500);
 
 /// Off-thread worker that writes submitted show files to disk.
 pub struct ShowSaver {
@@ -20,13 +23,7 @@ impl ShowSaver {
         let (tx, rx) = mpsc::channel::<SaveRequest>();
         let handle = thread::Builder::new()
             .name("show-saver".to_string())
-            .spawn(move || {
-                for req in rx {
-                    if let Err(e) = show_file::save(&req.path, &req.file) {
-                        log::error!("Show save failed for {}: {e:#}", req.path.display());
-                    }
-                }
-            })
+            .spawn(move || run(rx))
             .expect("failed to spawn show-saver thread");
         Self {
             tx,
@@ -40,5 +37,49 @@ impl ShowSaver {
         if let Err(e) = self.tx.send(SaveRequest { path, file }) {
             log::error!("Show saver channel closed: {e}");
         }
+    }
+}
+
+fn run(rx: mpsc::Receiver<SaveRequest>) {
+    let mut last_write: Option<Instant> = None;
+    let mut buffered: Option<SaveRequest> = None;
+    loop {
+        let recv_result = match (buffered.as_ref(), last_write) {
+            (Some(_), Some(t)) => {
+                let wait = (t + SAVE_THROTTLE).saturating_duration_since(Instant::now());
+                rx.recv_timeout(wait)
+            }
+            _ => rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
+        };
+        match recv_result {
+            Ok(req) => {
+                let can_fire = last_write.is_none_or(|t| t.elapsed() >= SAVE_THROTTLE);
+                if can_fire {
+                    write_or_log(&req);
+                    last_write = Some(Instant::now());
+                } else {
+                    buffered = Some(req);
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                if let Some(req) = buffered.take() {
+                    write_or_log(&req);
+                    last_write = Some(Instant::now());
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                if let Some(req) = buffered.take() {
+                    write_or_log(&req);
+                }
+                return;
+            }
+        }
+    }
+}
+
+fn write_or_log(req: &SaveRequest) {
+    match show_file::save(&req.path, &req.file) {
+        Ok(()) => log::debug!("Show saved to {}", req.path.display()),
+        Err(e) => log::error!("Show save failed for {}: {e:#}", req.path.display()),
     }
 }

--- a/src/show_saver.rs
+++ b/src/show_saver.rs
@@ -1,0 +1,44 @@
+use std::sync::mpsc;
+use std::thread;
+
+use crate::show_file::{self, ShowFile, ShowPath};
+
+/// Off-thread worker that writes submitted show files to disk.
+pub struct ShowSaver {
+    tx: mpsc::Sender<SaveRequest>,
+    _handle: thread::JoinHandle<()>,
+}
+
+struct SaveRequest {
+    path: ShowPath,
+    file: ShowFile,
+}
+
+impl ShowSaver {
+    /// Spawn the worker thread.
+    pub fn spawn() -> Self {
+        let (tx, rx) = mpsc::channel::<SaveRequest>();
+        let handle = thread::Builder::new()
+            .name("show-saver".to_string())
+            .spawn(move || {
+                for req in rx {
+                    if let Err(e) = show_file::save(&req.path, &req.file) {
+                        log::error!("Show save failed for {}: {e:#}", req.path.display());
+                    }
+                }
+            })
+            .expect("failed to spawn show-saver thread");
+        Self {
+            tx,
+            _handle: handle,
+        }
+    }
+
+    /// Submit a save request. Returns immediately; write errors surface in
+    /// the log.
+    pub fn submit(&self, path: ShowPath, file: ShowFile) {
+        if let Err(e) = self.tx.send(SaveRequest { path, file }) {
+            log::error!("Show saver channel closed: {e}");
+        }
+    }
+}


### PR DESCRIPTION
Rebuild how the show is saved, enabling saving and restoring data besides just the patch. Use this to include positioner state data in the show file.

Refactor show saving to be the responsibility of a dedicated thread, draining a channel and throttling how often save happens to avoid thrashing on rapid-fire edits (save at most twice a second).

Expand the job of GuiDirty into StateDirty, and use that to drive taking show snapshots and sending them to the saver thread. Add the important Positioner state into the show saving and loading mechanism.
