### PR TITLE
Major improvements to HSLuv.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
  "gethostname",
  "gui_common",
  "hsluv",
+ "image",
  "itertools 0.14.0",
  "linkme",
  "local-ip-address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ objc2-foundation = "0.2"
 typetag = "0.2"
 tempfile = "3"
 egui_kittest = { version = "0.33", features = ["wgpu", "snapshot"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 # [patch.'https://github.com/generalelectrix/tunnels']
 # midi_harness = { path = "../tunnels/midi_harness" }

--- a/RGBW_BRIGHTNESS.md
+++ b/RGBW_BRIGHTNESS.md
@@ -1,0 +1,233 @@
+# RGBW White-Diode Brightness Notes
+
+Working notes on how bright the W diode is relative to the chromatic R, G, B diodes
+on common entertainment LED hardware. These numbers drive `W_DIODE_BRIGHTNESS` in
+`src/color.rs` and frame why the HSLuv→RGBW and HSI→RGBW conversions choose
+different strategies.
+
+## The `k_w` concept
+
+Let `k_w` be the W diode's luminous output, at full drive, expressed in
+"chromatic-channel-units" — where 1 chromatic-channel-unit is the lumens emitted
+by a single R, G, or B die at the same drive current. Three values bracket the
+useful range:
+
+| `k_w` | Means | Implied algorithm |
+|------:|:------|:------------------|
+| 1.0 | W ≈ one chromatic LED | saikoled HSI→RGBW ([blog](https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white)) |
+| 2.0 | W ≈ two chromatic LEDs | brightness-aware white subtraction |
+| 3.0 | W ≈ R+G+B equal-mix | naive white subtraction |
+
+Real fixtures sit somewhere on this axis. Picking the wrong value leaves either
+desaturated colors too bright (over-estimate W) or too dim (under-estimate W).
+
+## Findings across hardware regimes
+
+| Hardware | `k_w` (W ÷ R+G+B summed photometric) |
+|:---------|:-------------------------------------|
+| Analog 5050 RGBW LED strip (24 V) | ≈ 0.8 |
+| SK6812 RGBW addressable pixel | ≈ 0.85 |
+| SaikoLED MyKi (algorithm design target, 2013) | ≈ 1.0 |
+| **4-die quad LED PAR (Cree XM-L Color, Luxeon C Color)** | **≈ 2.0** |
+| **6-die hex PAR (Osram OSTAR Stage / Chinese hex)** | **≈ 1.7–2.0** |
+
+The factor of ~2× between pixel strings/strips and entertainment-grade pars is the
+dominant story. Cobra runs on PARs and hex pars, so `k_w = 2.0` is the right
+default. Pixel strings would want `k_w ≈ 1.0` if Cobra ever supports them
+natively.
+
+## Detail per regime
+
+### 4-die quad RGBW pars (k_w ≈ 2.0)
+
+The canonical part is **Cree XM-L Color RGBW** ([LEDsupply](https://www.ledsupply.com/leds/cree-xml-rgbw-star-led)),
+behind many "quad" or "quad-color" wash pars. Minimum-bin lumens at 350 mA per
+channel:
+
+| Channel | Lumens |
+|---------|-------:|
+| White (cool) | 80–100 |
+| Green | 87.4 |
+| Red | 45.7 |
+| Royal-Blue | 13.9 (radiometric; ~25–40 lm photometric blue) |
+| **R+G+B summed photometric** | **~145–160 lm** |
+
+→ W ≈ 55–65% of R+G+B sum ≈ **2.0× a single chromatic channel** ≈ 1.0× green alone.
+
+**Lumileds Luxeon C Color** ([product page](https://lumileds.com/products/color-leds/luxeon-c-colors/),
+[datasheet](https://www.ledsupply.com/content/pdf/Luxeon-c-color-line-datasheet.pdf))
+shows the same pattern: R+G+B ≈ 233 lm at 350 mA, W ≈ 100–130 lm cool-white,
+again ~50% of R+G+B sum.
+
+**Why this `k_w`:** the W die is phosphor-converted blue (InGaN pump + YAG:Ce or
+similar), which has roughly **2× the luminous efficacy** of an RGB-mixed white at
+the system level (the "green gap" and red Stokes-shift inefficiency penalize RGB
+mixing). The chromatic dies and the W die share the same drive current with no
+calibration — manufacturers wire them at identical I_F and let the lumens fall
+where they fall.
+
+### 6-die hex RGBWAU pars (k_w ≈ 1.7–2.0)
+
+Hex pars (ADJ Mega Hex Par, Chauvet COLORdash Hex, Elation Sixpar, Eurolite
+PAR-64 HCL RGBAWUV) use either the **Osram OSTAR Stage LE RTDUW** family or
+generic Chinese 6-in-1 dies. Osram publishes per-channel data:
+
+- **LE RTDUW S2W** at 1 A typical: R ≈ 140 lm, G ≈ 280 lm, B ≈ 50 lm (binned),
+  W ≈ 355 lm ([Farnell datasheet](https://www.farnell.com/datasheets/2034550.pdf))
+- **LE RTDUW S2WN** at 1 A typical: R 90–140 lm, G 180–355 lm, W 224–450 lm
+  ([Mouser datasheet](https://www.mouser.com/pdfDocs/LERTDUWS2WN_ENDatasheet.pdf))
+- **LE RTDUW S2WP** at 1.4 A: R 112–280 lm, G 280–710 lm, W up to ~710 lm
+  ([ams-osram datasheet](https://look.ams-osram.com/m/d9e4a1902c08390/original/LE-RTDUW-S2WP.pdf))
+
+→ W is approximately equal to R+G+B summed at equal I_F, giving k_w ≈ 1.7–2.0,
+same as the 4-die quad case.
+
+**Why the same `k_w` despite the die-count change:** going quad → hex shrinks
+every die by ~33% (six dies share the same dome instead of four), but the W:RGB
+brightness *ratio* is preserved because phosphor white's lm/mm² is class-bound,
+not size-bound. Absolute lumens fall together; the ratio survives.
+
+**Amber** (590 nm) at equal drive gives ~0.5–0.8× a red's lumens
+([Moon LEDs technical brief](https://www.moon-leds.com/news-what-is-amber-led-pc-amber-1800k-2200k-monochromatic-amber.html)).
+**UV** (365/395 nm) is < 0.5 lm/W photopic
+([Waveform Lighting](https://www.waveformlighting.com/tech/top-4-things-to-consider-before-buying-uv-blacklights))
+— treat as zero photometric contribution.
+
+Fixture vendors (ADJ Mega Hex, Elation [SixPar 200](https://www.elationlighting.com/products/sixpar-200) /
+[SixPar 300](https://www.elationlighting.com/products/sixpar-300), Chauvet
+[COLORdash Par H7X](https://chauvetprofessional.com/product/colordash-par-h7x-ip/),
+[Eurolite PAR-64 HCL RGBAWUV](https://www.prolighting.de/en/lighting-effects/spotlights/led-spots/eurolite-led-par-64-hcl-12x10w-floor-schwarz-rgbawuv.html))
+publish only total fixture lumens or peak lux, never per-channel — the
+component-level data from Osram / Lumileds is the only triangulation route.
+
+### Addressable pixel strings (k_w ≈ 0.85)
+
+**SK6812 RGBW** (the canonical "NeoPixel RGBW" part, sold by Adafruit and
+BTF-Lighting) at 13 mA per channel
+([Normand LED datasheet](https://www.normandled.com/upload/201805/SK6812RGBX-XX%20Datasheet.pdf),
+[Adafruit-hosted Rev01](https://cdn-shop.adafruit.com/product-files/2757/p2757_SK6812RGBW_REV01.pdf)):
+
+| Channel | Lumens @ 13 mA |
+|---------|---------------:|
+| Red | 1.0–2.0 |
+| Green | 3.0–5.0 |
+| Blue | 1.0–2.0 |
+| White (CW 6000–7000 K) | 5.0–7.0 |
+
+→ W ≈ 6 lm vs R+G+B ≈ 7 lm summed → **k_w ≈ 0.85**.
+
+The package puts four discrete dies under a single 5050 dome
+([BTF-Lighting product page](https://www.btf-lighting.com/products/sk6812similar-ws2812b-rgbw-rgbnature-warm-white-5050-smd-individually-addressable-digital-led-chip-pixels-dc-5v),
+[LEDYi technical comparison](https://www.ledyilighting.com/sk6812-vs-ws2812b-which-led-strip-light-is-best-why/)).
+The W die is a separately-fabricated phosphor-white chip of *comparable area* to
+each chromatic die — confirmed by the fact that driving blue alone faintly
+excites the W phosphor by package proximity. Unlike entertainment pars, the W
+die here doesn't dominate by area, so its lumen advantage from phosphor
+efficacy is muted.
+
+### Analog 5050 RGBW strips (k_w ≈ 0.8)
+
+Same 5050 4-in-1 die as SK6812 RGBW, just non-addressable (24 V or 12 V common
+anode). Representative per-channel spec for a 60 LED/m strip:
+R 128 / G 326 / B 82 / W 432 lm/m
+([ledmyplace product spec](https://www.ledmyplace.com/products/rgbw-led-strip-lights-12v-led-tape-light-w-white-366-lumens-ft),
+[Super Bright LEDs](https://www.superbrightleds.com/5m-rgbw-led-strip-light-4-in-1-chip-5050-color-changing-led-tape-light-12v-24v-ip20)).
+
+→ W / (R+G+B) ≈ 432 / 536 ≈ **0.81** — same ballpark as SK6812.
+
+### SaikoLED MyKi (k_w ≈ 1.0)
+
+The HSI→RGBW saikoled algorithm was developed for the
+**[SaikoLED MyKi](https://www.crowdsupply.com/saiko-led/myki-led-light)**, a
+12 W RGBW spotlight architected with **3 W per chromatic channel + 3 W for
+white** — equal electrical power per channel. On the mid-power phosphor whites
+available in 2013 that yields W ≈ 1× single chromatic channel photometric, i.e.
+k_w ≈ 1.0.
+
+The saikoled HSI→RGBW math reads `W = (1-S)·I` with no scaling
+([blog post](https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white)).
+That's only correct when k_w ≈ 1.0. Porting the same algorithm to entertainment
+PARs (k_w ≈ 2.0) over-drives W by ~2×, causing desaturated mixes to come out
+chalky and washed-out.
+
+## Algorithm implications
+
+Two candidate RGBW conversion strategies, both implicitly assuming some `k_w`:
+
+- **Naive white subtraction** (`W = min(R,G,B); R,G,B -= W`) assumes
+  **k_w = 3** (W ≈ R+G+B equal-mix). On a real par (k_w ≈ 2) this
+  *over*-estimates W, so pastels emit ~33% less light than HSLuv intended.
+- **SaikoLED HSI→RGBW** (`W = (1-S)·I`, chromatic scaled by `S·I/3`) assumes
+  **k_w = 1**. On a real par this *under*-estimates W, so desaturated colors
+  come out ~2× brighter than HSI intensity intended.
+
+The fix used by `Hsv::rgbw()` and `Hsluv::rgbw()` in `src/color.rs` is
+**brightness-aware white subtraction**, generalized over `k_w`. Both methods
+convert their source space to linear RGB and then call a shared
+`linear_rgb_to_rgbw` helper:
+
+```rust
+let m = r.min(g).min(b);
+let w = (3.0 * m / W_DIODE_BRIGHTNESS).min(1.0);
+let c = w * W_DIODE_BRIGHTNESS / 3.0;
+// emit (r - c, g - c, b - c, w)
+```
+
+At `k_w = 3` this collapses to naive white subtraction; at `k_w = 1` it
+approaches the saikoled W allocation; at `k_w = 2` it matches typical
+entertainment pars. The "one chromatic channel always zero" property holds
+except on near-white inputs (`min(r,g,b) > k_w/3`) where W saturates and the
+chromatic channels carry the residual achromatic load — physically correct
+behavior because W can't get any brighter.
+
+`Hsi::rgbw` deliberately does NOT use this helper — HSI's intensity invariant
+(constant total LED drive) is incompatible with white subtraction's lightness
+invariant, so HSI keeps the saikoled sector scheme.
+
+**HSI's sector scheme isn't redundant — it solves a different problem.** HSI's
+contract is "intensity = total LED drive across all diodes, constant for any
+(h, s)"; the sector algorithm is constructed to maintain that invariant.
+HSLuv's contract is *perceptual lightness*, which brightness-aware white
+subtraction preserves on any fixture with a correctly-tuned `k_w`. Each
+algorithm matches its color space's semantics.
+
+## Second-order knobs
+
+Two factors move `k_w` within a hardware class:
+
+1. **W color temperature.** Cool white (~6000 K) has higher photopic efficacy
+   than warm white (~3000 K). Warm-white parts skew toward k_w ≈ 1.0 even in
+   par form factors; cool-white pixels skew toward k_w ≈ 1.0+ where strips
+   would otherwise be 0.8. If per-fixture calibration ever becomes a thing,
+   parameterize on W CCT, not die count.
+2. **Drive-current calibration.** Some higher-end fixtures (Robe, Martin) do
+   calibrate W drive current to balance perceived brightness; cheap fixtures
+   never do. Assume "no calibration" for the bulk of the market.
+
+## Sources
+
+- [SaikoLED: How to convert from HSI to RGB+White](https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white)
+- [SaikoLED: Why every LED light should be using HSI](https://blog.saikoled.com/post/43693602826/why-every-led-light-should-be-using-hsi)
+- [SaikoLED MyKi — Crowd Supply](https://www.crowdsupply.com/saiko-led/myki-led-light)
+- [Cree XM-L Color RGBW (LEDSupply)](https://www.ledsupply.com/leds/cree-xml-rgbw-star-led)
+- [Lumileds Luxeon C Color Line](https://lumileds.com/products/color-leds/luxeon-c-colors/)
+- [Luxeon C Color Line datasheet](https://www.ledsupply.com/content/pdf/Luxeon-c-color-line-datasheet.pdf)
+- [SK6812RGBX-XX datasheet (Normand LED)](https://www.normandled.com/upload/201805/SK6812RGBX-XX%20Datasheet.pdf)
+- [SK6812RGBW Rev01 (Adafruit-hosted)](https://cdn-shop.adafruit.com/product-files/2757/p2757_SK6812RGBW_REV01.pdf)
+- [Adafruit NeoPixel RGBW Strip Product 2824](https://www.adafruit.com/product/2824)
+- [BTF-Lighting SK6812 RGBW product page](https://www.btf-lighting.com/products/sk6812similar-ws2812b-rgbw-rgbnature-warm-white-5050-smd-individually-addressable-digital-led-chip-pixels-dc-5v)
+- [LEDYi: SK6812 vs WS2812B technical comparison](https://www.ledyilighting.com/sk6812-vs-ws2812b-which-led-strip-light-is-best-why/)
+- [Osram LE RTDUW S2W datasheet](https://www.farnell.com/datasheets/2034550.pdf)
+- [Osram LE RTDUW S2WN datasheet](https://www.mouser.com/pdfDocs/LERTDUWS2WN_ENDatasheet.pdf)
+- [Osram LE RTDUW S2WP datasheet](https://look.ams-osram.com/m/d9e4a1902c08390/original/LE-RTDUW-S2WP.pdf)
+- [Cree app note: Optimizing 4-Channel Color Mixing](https://www.cree-led.com/news/ap-note-optimizing-4-channel-color-mixing-systems-for-color-rendering/)
+- [ledmyplace RGBW 5050 60 LED/m spec](https://www.ledmyplace.com/products/rgbw-led-strip-lights-12v-led-tape-light-w-white-366-lumens-ft)
+- [Super Bright LEDs 5050 RGBW strip](https://www.superbrightleds.com/5m-rgbw-led-strip-light-4-in-1-chip-5050-color-changing-led-tape-light-12v-24v-ip20)
+- [Chauvet COLORdash Par H7X IP](https://chauvetprofessional.com/product/colordash-par-h7x-ip/)
+- [Elation SixPar 200](https://www.elationlighting.com/products/sixpar-200)
+- [Elation SixPar 300](https://www.elationlighting.com/products/sixpar-300)
+- [ADJ Mega Hex Par](https://www.adj.com/mega-hex-par)
+- [Eurolite PAR-64 HCL RGBAWUV](https://www.prolighting.de/en/lighting-effects/spotlights/led-spots/eurolite-led-par-64-hcl-12x10w-floor-schwarz-rgbawuv.html)
+- [Moon LEDs: PC amber 590 nm efficacy](https://www.moon-leds.com/news-what-is-amber-led-pc-amber-1800k-2200k-monochromatic-amber.html)
+- [Waveform Lighting: UV blacklight lm/W](https://www.waveformlighting.com/tech/top-4-things-to-consider-before-buying-uv-blacklights)
+- [NCBI: LED efficacy review](https://pmc.ncbi.nlm.nih.gov/articles/PMC7105460/)

--- a/examples/color_space_comparison.rs
+++ b/examples/color_space_comparison.rs
@@ -1,0 +1,329 @@
+//! Throwaway PNG generator that compares how HSV, HSI, and HSLuv each render
+//! into RGB and RGBW emitter spaces.
+//!
+//! Output layout (rows × cols):
+//!     HSV   RGB | HSV   RGBW
+//!     HSI   RGB | HSI   RGBW
+//!     HSLuv RGB | HSLuv RGBW
+//!
+//! Each panel is a hue × saturation grid. Each cell is a perceived-color
+//! swatch on top with grayscale per-diode strips beneath, so the W diode's
+//! contribution is visible even on an sRGB monitor.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+use cobra_commander::color::{
+    HSLUV_LIGHTNESS_OFFSET, Hsi, Hsluv, Hsv, RenderColor, W_DIODE_BRIGHTNESS,
+};
+use image::{ImageBuffer, Rgb};
+use number::{Phase, UnipolarFloat};
+
+#[derive(Parser)]
+struct Args {
+    /// Output PNG path.
+    #[clap(long, default_value = "target/color_space_comparison.png")]
+    output: PathBuf,
+
+    /// HSLuv lightness. Defaults to [`HSLUV_LIGHTNESS_OFFSET`] — the level at
+    /// which all three primaries are at the brightness of full blue, which
+    /// produces the most chromatically informative comparison.
+    #[clap(long)]
+    hsluv_lightness: Option<f64>,
+
+    /// W-diode brightness ratio used when simulating RGBW output on an sRGB
+    /// monitor. Defaults to [`W_DIODE_BRIGHTNESS`] — set this to investigate
+    /// what the conversion looks like on a fixture with a different real ratio.
+    #[clap(long)]
+    simulated_kw: Option<f64>,
+
+    /// Hue samples per panel (cell columns).
+    #[clap(long, default_value_t = 60)]
+    hue_steps: u32,
+
+    /// Saturation samples per panel (cell rows; sat = 1 at the top).
+    #[clap(long, default_value_t = 8)]
+    sat_steps: u32,
+
+    /// Cell width in pixels.
+    #[clap(long, default_value_t = 16)]
+    cell_w: u32,
+
+    /// Swatch (perceived color) height in pixels at the top of each cell.
+    #[clap(long, default_value_t = 24)]
+    swatch_h: u32,
+
+    /// Per-diode strip height in pixels (3 strips for RGB, 4 for RGBW).
+    #[clap(long, default_value_t = 6)]
+    strip_h: u32,
+
+    /// Gutter in pixels between panels.
+    #[clap(long, default_value_t = 16)]
+    gutter: u32,
+}
+
+#[derive(Clone, Copy)]
+enum Space {
+    Hsv,
+    Hsi,
+    Hsluv,
+}
+
+impl Space {
+    const ALL: [Space; 3] = [Space::Hsv, Space::Hsi, Space::Hsluv];
+    fn label(self) -> &'static str {
+        match self {
+            Space::Hsv => "HSV",
+            Space::Hsi => "HSI",
+            Space::Hsluv => "HSLuv",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Gamut {
+    Rgb,
+    Rgbw,
+}
+
+impl Gamut {
+    const ALL: [Gamut; 2] = [Gamut::Rgb, Gamut::Rgbw];
+    fn n_diodes(self) -> u32 {
+        match self {
+            Gamut::Rgb => 3,
+            Gamut::Rgbw => 4,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            Gamut::Rgb => "RGB",
+            Gamut::Rgbw => "RGBW",
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let lightness = match args.hsluv_lightness {
+        Some(x) => UnipolarFloat::new(x.clamp(0.0, 1.0)),
+        None => HSLUV_LIGHTNESS_OFFSET,
+    };
+    let simulated_kw = args.simulated_kw.unwrap_or(W_DIODE_BRIGHTNESS);
+
+    // Cells differ in height between RGB (3 strips) and RGBW (4 strips); pick
+    // the larger so panel rows align even though the row content differs.
+    let cell_h_max = args.swatch_h + 4 * args.strip_h;
+    let panel_w = args.cell_w * args.hue_steps;
+    let panel_h = cell_h_max * args.sat_steps;
+
+    let n_cols = Gamut::ALL.len() as u32;
+    let n_rows = Space::ALL.len() as u32;
+    let total_w = n_cols * panel_w + (n_cols + 1) * args.gutter;
+    let total_h = n_rows * panel_h + (n_rows + 1) * args.gutter;
+
+    let bg = Rgb([24u8, 24, 24]);
+    let mut img: ImageBuffer<Rgb<u8>, Vec<u8>> = ImageBuffer::from_pixel(total_w, total_h, bg);
+
+    for (row, space) in Space::ALL.iter().enumerate() {
+        for (col, gamut) in Gamut::ALL.iter().enumerate() {
+            let panel_x = args.gutter + (col as u32) * (panel_w + args.gutter);
+            let panel_y = args.gutter + (row as u32) * (panel_h + args.gutter);
+            render_panel(
+                &mut img,
+                panel_x,
+                panel_y,
+                *space,
+                *gamut,
+                &args,
+                lightness,
+                simulated_kw,
+            );
+        }
+    }
+
+    if let Some(parent) = args.output.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    img.save(&args.output)?;
+
+    println!(
+        "wrote {} ({}x{} px)",
+        args.output.display(),
+        total_w,
+        total_h
+    );
+    println!(
+        "  rows (top→bottom): {}",
+        Space::ALL
+            .iter()
+            .map(|s| s.label())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    println!(
+        "  cols (left→right): {}",
+        Gamut::ALL
+            .iter()
+            .map(|g| g.label())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    println!("  per cell: swatch on top, then per-diode grayscale strips (R, G, B[, W])");
+    println!("  hsluv lightness: {:.4}", lightness.val());
+    println!("  simulated kw:    {:.4}", simulated_kw);
+    Ok(())
+}
+
+fn render_panel(
+    img: &mut ImageBuffer<Rgb<u8>, Vec<u8>>,
+    panel_x: u32,
+    panel_y: u32,
+    space: Space,
+    gamut: Gamut,
+    args: &Args,
+    lightness: UnipolarFloat,
+    simulated_kw: f64,
+) {
+    let n_strips = gamut.n_diodes();
+    let cell_h = args.swatch_h + 4 * args.strip_h; // align row heights across gamuts
+
+    for sy in 0..args.sat_steps {
+        let sat = sat_for_row(sy, args.sat_steps);
+        for hx in 0..args.hue_steps {
+            let hue = Phase::new((hx as f64) / (args.hue_steps as f64));
+            let cell = build_cell(space, gamut, hue, sat, lightness, simulated_kw);
+
+            let cx = panel_x + hx * args.cell_w;
+            let cy = panel_y + sy * cell_h;
+
+            fill_rect(img, cx, cy, args.cell_w, args.swatch_h, Rgb(cell.swatch));
+            for (i, drive) in cell.diodes.iter().enumerate().take(n_strips as usize) {
+                let g = *drive;
+                let strip_y = cy + args.swatch_h + (i as u32) * args.strip_h;
+                fill_rect(img, cx, strip_y, args.cell_w, args.strip_h, Rgb([g, g, g]));
+            }
+        }
+    }
+}
+
+fn sat_for_row(sy: u32, sat_steps: u32) -> UnipolarFloat {
+    if sat_steps <= 1 {
+        UnipolarFloat::ONE
+    } else {
+        let t = (sy as f64) / ((sat_steps - 1) as f64);
+        UnipolarFloat::new((1.0 - t).clamp(0.0, 1.0))
+    }
+}
+
+struct Cell {
+    swatch: [u8; 3],
+    diodes: [u8; 4], // index 3 is W; ignored for RGB gamut
+}
+
+fn build_cell(
+    space: Space,
+    gamut: Gamut,
+    hue: Phase,
+    sat: UnipolarFloat,
+    lightness: UnipolarFloat,
+    simulated_kw: f64,
+) -> Cell {
+    match (space, gamut) {
+        (Space::Hsv, Gamut::Rgb) => {
+            let c = Hsv {
+                hue,
+                sat,
+                val: UnipolarFloat::ONE,
+            };
+            cell_from_rgb(c.rgb())
+        }
+        (Space::Hsv, Gamut::Rgbw) => {
+            let c = Hsv {
+                hue,
+                sat,
+                val: UnipolarFloat::ONE,
+            };
+            cell_from_rgbw(c.rgbw(), simulated_kw)
+        }
+        (Space::Hsi, Gamut::Rgb) => {
+            let c = Hsi {
+                hue,
+                sat,
+                intensity: UnipolarFloat::ONE,
+            };
+            cell_from_rgb(c.rgb())
+        }
+        (Space::Hsi, Gamut::Rgbw) => {
+            let c = Hsi {
+                hue,
+                sat,
+                intensity: UnipolarFloat::ONE,
+            };
+            cell_from_rgbw(c.rgbw(), simulated_kw)
+        }
+        (Space::Hsluv, Gamut::Rgb) => {
+            let c = Hsluv {
+                hue,
+                sat,
+                lightness,
+            };
+            cell_from_rgb(c.rgb())
+        }
+        (Space::Hsluv, Gamut::Rgbw) => {
+            let c = Hsluv {
+                hue,
+                sat,
+                lightness,
+            };
+            cell_from_rgbw(c.rgbw(), simulated_kw)
+        }
+    }
+}
+
+fn cell_from_rgb(rgb: [u8; 3]) -> Cell {
+    Cell {
+        swatch: rgb,
+        diodes: [rgb[0], rgb[1], rgb[2], 0],
+    }
+}
+
+fn cell_from_rgbw(rgbw: [u8; 4], kw: f64) -> Cell {
+    let r = rgbw[0] as f64 / 255.0;
+    let g = rgbw[1] as f64 / 255.0;
+    let b = rgbw[2] as f64 / 255.0;
+    let w = rgbw[3] as f64 / 255.0;
+    let contrib = w * kw / 3.0;
+    let to_u8 = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    Cell {
+        swatch: [to_u8(r + contrib), to_u8(g + contrib), to_u8(b + contrib)],
+        diodes: rgbw,
+    }
+}
+
+fn fill_rect(
+    img: &mut ImageBuffer<Rgb<u8>, Vec<u8>>,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    color: Rgb<u8>,
+) {
+    let (img_w, img_h) = (img.width(), img.height());
+    for dy in 0..h {
+        let py = y + dy;
+        if py >= img_h {
+            break;
+        }
+        for dx in 0..w {
+            let px = x + dx;
+            if px >= img_w {
+                break;
+            }
+            img.put_pixel(px, py, color);
+        }
+    }
+}

--- a/src/color.rs
+++ b/src/color.rs
@@ -49,13 +49,7 @@ impl RenderColor for Hsv {
         hsv_to_rgb(self.hue, self.sat, self.val)
     }
     fn rgbw(&self) -> ColorRgbw {
-        let [r, g, b] = self.rgb();
-        // FIXME: this is a shitty way to use the white diode.
-        // We should rescale the other values to maintain total brightness while
-        // bringing in white for pastels. This will take some thinking, and won't
-        // work for all colors.
-        let w = unit_to_u8((self.sat.invert() * self.val).val());
-        [r, g, b, w]
+        linear_rgb_to_rgbw(self.linear_rgb())
     }
     fn hsv(&self) -> ColorHsv {
         // This controller defines green as hue = 0.
@@ -67,6 +61,13 @@ impl RenderColor for Hsv {
             unit_to_u8(self.sat.val()),
             unit_to_u8(self.val.val()),
         ]
+    }
+}
+
+impl Hsv {
+    /// HSV to linear sRGB in `[0, 1]`.
+    fn linear_rgb(&self) -> (f64, f64, f64) {
+        hsv_to_linear_rgb(self.hue, self.sat, self.val)
     }
 }
 
@@ -115,6 +116,25 @@ pub struct Hsluv {
 
 impl RenderColor for Hsluv {
     fn rgb(&self) -> ColorRgb {
+        let (r, g, b) = self.linear_rgb();
+        [unit_to_u8(r), unit_to_u8(g), unit_to_u8(b)]
+    }
+
+    fn rgbw(&self) -> ColorRgbw {
+        linear_rgb_to_rgbw(self.linear_rgb())
+    }
+
+    fn hsv(&self) -> ColorHsv {
+        warn!("HSV output rendering is not implemented for HSLuv");
+        [0, 0, 0]
+    }
+}
+
+impl Hsluv {
+    /// HSLuv to linear sRGB in `[0, 1]`, with the hue circle rescaled so that
+    /// the RGB primaries sit exactly 120° apart and out-of-gamut channels
+    /// clipped to the displayable range.
+    fn linear_rgb(&self) -> (f64, f64, f64) {
         // HSLuv library uses degrees for phase and percent for other two components.
         // Primary and secondary hues at base lightness (renders primary blue) are:
         // (r, y, g, c, b, m): (12.2, 85.8, 127.7, 191.6, 265.87, 307.7)
@@ -157,26 +177,23 @@ impl RenderColor for Hsluv {
             self.sat.val() * 100.,
             self.lightness.val() * 100.,
         );
-        [unit_to_u8(r), unit_to_u8(g), unit_to_u8(b)]
-    }
-
-    fn rgbw(&self) -> ColorRgbw {
-        // TODO: we have lots of rich info about our input color, we should be
-        // able to make good use of the white diode.
-        // Inspiration: https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
-        let [r, g, b] = self.rgb();
-        [r, g, b, 0]
-    }
-
-    fn hsv(&self) -> ColorHsv {
-        warn!("HSV output rendering is not implemented for HSLuv");
-        [0, 0, 0]
+        (r.clamp(0., 1.), g.clamp(0., 1.), b.clamp(0., 1.))
     }
 }
 
 /// This is the lightness value where the gamut contains all three primary colors
 /// at the brightness equivalent to blue at maximum output.
 pub const HSLUV_LIGHTNESS_OFFSET: UnipolarFloat = UnipolarFloat::new(0.3225);
+
+/// W diode luminous output relative to a single chromatic LED, expressed in
+/// chromatic-channel-units.
+///
+/// Typical entertainment-grade RGBW pars (Cree XM-L Color, Luxeon C Color)
+/// and six-die hex pars (Osram OSTAR Stage) sit near 2.0. A value of 3.0
+/// corresponds to the idealized "W = R+G+B equal-mix" regime; 1.0
+/// corresponds to the saikoled HSI→RGBW regime, appropriate for
+/// SK6812-class pixel strings and warm-white phosphor parts.
+pub const W_DIODE_BRIGHTNESS: f64 = 2.0;
 
 /// An HSV color in an output 24-bit space.
 /// This is an uncommon output model, but a few models of DMX fixture do use it.
@@ -196,10 +213,14 @@ pub type ColorRgbw = [u8; 4];
 /// This makes it easy to turn a knob between yellow, red, and magenta without
 /// passing through green.
 pub fn hsv_to_rgb(hue: Phase, sat: UnipolarFloat, val: UnipolarFloat) -> ColorRgb {
+    let (r, g, b) = hsv_to_linear_rgb(hue, sat, val);
+    [unit_to_u8(r), unit_to_u8(g), unit_to_u8(b)]
+}
+
+fn hsv_to_linear_rgb(hue: Phase, sat: UnipolarFloat, val: UnipolarFloat) -> (f64, f64, f64) {
     let hue = hue + 1. / 3.;
     if sat == 0.0 {
-        let v = unit_to_u8(val.val());
-        return [v, v, v];
+        return (val.val(), val.val(), val.val());
     }
     let var_h = if hue == 1.0 { 0.0 } else { hue.val() * 6.0 };
 
@@ -208,15 +229,14 @@ pub fn hsv_to_rgb(hue: Phase, sat: UnipolarFloat, val: UnipolarFloat) -> ColorRg
     let var_2 = val.val() * (1.0 - sat.val() * (var_h - var_i));
     let var_3 = val.val() * (1.0 - sat.val() * (1.0 - (var_h - var_i)));
 
-    let (rv, gv, bv) = match var_i as i64 {
+    match var_i as i64 {
         0 => (val.val(), var_3, var_1),
         1 => (var_2, val.val(), var_1),
         2 => (var_1, val.val(), var_3),
         3 => (var_1, var_2, val.val()),
         4 => (var_3, var_1, val.val()),
         _ => (val.val(), var_1, var_2),
-    };
-    [unit_to_u8(rv), unit_to_u8(gv), unit_to_u8(bv)]
+    }
 }
 
 /// Convert unit-scaled HSI into a 24-bit RGB color.
@@ -305,6 +325,31 @@ pub fn hsi_to_rgbw(hue: Phase, sat: UnipolarFloat, intensity: UnipolarFloat) -> 
         unit_to_u8(i_scale * gv),
         unit_to_u8(i_scale * bv),
         unit_to_u8((1. - sat.val()) * intensity.val()),
+    ]
+}
+
+/// Convert linear RGB in `[0, 1]` to an RGBW drive vector via
+/// brightness-aware white subtraction.
+///
+/// The achromatic minimum of the input is migrated to the W channel, scaled
+/// by [`W_DIODE_BRIGHTNESS`] to compensate for the W diode's lumen output
+/// relative to a single chromatic diode. On a fixture whose W actually
+/// emits `W_DIODE_BRIGHTNESS` chromatic-channel-units of light, the
+/// four-channel output reproduces the spectrum the chromatic channels
+/// would emit alone, so chromaticity and brightness are preserved.
+///
+/// Exactly one of R/G/B is zero except on near-white inputs where W
+/// saturates at unit drive, in which case the chromatic channels carry
+/// the residual achromatic load.
+fn linear_rgb_to_rgbw((r, g, b): (f64, f64, f64)) -> ColorRgbw {
+    let m = r.min(g).min(b);
+    let w = (3. * m / W_DIODE_BRIGHTNESS).min(1.);
+    let c = w * W_DIODE_BRIGHTNESS / 3.;
+    [
+        unit_to_u8(r - c),
+        unit_to_u8(g - c),
+        unit_to_u8(b - c),
+        unit_to_u8(w),
     ]
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -131,47 +131,66 @@ impl RenderColor for Hsluv {
 }
 
 impl Hsluv {
-    /// HSLuv to linear sRGB in `[0, 1]`, with the hue circle rescaled so that
-    /// the RGB primaries sit exactly 120° apart and out-of-gamut channels
+    /// HSLuv to linear sRGB in `[0, 1]`. The hue coordinate is mapped via a
+    /// 24-anchor Catmull-Rom approximation of
+    ///
+    ///   f(u) = HSLuv_hue( HSV(u, sat=1, val=1) )
+    ///
+    /// so that named hues land at their HSV positions and the within-
+    /// segment sweep follows HSV's RGB-uniform shape rather than CIELUV's
+    /// perceptual-uniformity expansion of green and yellow. Saturation and
+    /// lightness are interpreted as HSLuv values. Out-of-gamut channels are
     /// clipped to the displayable range.
     fn linear_rgb(&self) -> (f64, f64, f64) {
-        // HSLuv library uses degrees for phase and percent for other two components.
-        // Primary and secondary hues at base lightness (renders primary blue) are:
-        // (r, y, g, c, b, m): (12.2, 85.8, 127.7, 191.6, 265.87, 307.7)
-        // Subtracting 127.7 to shift primary green to 0 gives:
-        // (r, y, g, c, b, m): (244.5, 318.1, 0.0, 63.9, 138.17, 180.0)
+        // The exact `f` above asks "what HSLuv hue produces the same
+        // chromaticity as HSV at this input?" Calling its closed form
+        // requires two hsluv-crate round-trips per render; the spline
+        // below approximates `f` directly so the runtime cost is one
+        // hsluv_to_rgb call plus a handful of multiplies.
+        //
+        // `f` has surprising shape: it's nearly flat at the three RGB
+        // primaries (tangent ≈ 2°/unit-t) because pure-primary HSV stays
+        // near its HSLuv counterpart under small chromatic perturbations,
+        // and very steep between primary and secondary (tangent
+        // approaching 40°/unit-t through cyan and yellow) where the
+        // HSV→RGB mix moves the chromaticity quickly around the wheel.
+        // 24 anchors uniformly spaced in user input capture the curvature
+        // to within ~0.74° max error vs the exact inverse.
+        //
+        // Values are unwrapped (monotonically increasing past 360°) so
+        // the segment math doesn't need to handle the green↔red wrap.
+        // hsluv_to_rgb accepts angles > 360° and wraps internally.
+        const N_SEG: usize = 24;
+        const ANCHOR_DEG: [f64; N_SEG] = [
+            127.7150, 129.6099, 136.6877, 155.0453, 192.1771, 233.5490, 255.5095, 263.7201,
+            265.8743, 267.9638, 274.9051, 288.4547, 307.7150, 331.9367, 355.3484, 368.3239,
+            372.1771, 376.0787, 389.9437, 417.2823, 445.8743, 466.4839, 479.5531, 485.8594,
+        ];
+        // Catmull-Rom tangents (df/dt with t ∈ [0, 1] spanning one segment).
+        const ANCHOR_TAN: [f64; N_SEG] = [
+            1.8752, 4.4864, 12.7177, 27.7447, 39.2519, 31.6662, 15.0855, 5.1824, 2.1219, 4.5154,
+            10.2454, 16.4049, 21.7410, 23.8167, 18.1936, 8.4143, 3.8774, 8.8833, 20.6018, 27.9653,
+            24.6008, 16.8394, 9.6877, 4.0810,
+        ];
 
-        // Observations:
-        // - each primary and opposing secondary are actually 180 degrees apart
-        // - the primary to primary distance and primary to secondary distance
-        //   varies quite a bit, presumably due to our ability to resolve subtle
-        //   hue variations in each range differently. This isn't great for art,
-        //   though, since too much of our hue range is dedicated to shades of
-        //   green. Rescale the ranges to give each subset an equal share of
-        //   the hue range.
-
-        // Perform operations in the unit range.
-        const RED: f64 = 244.5 / 360.;
-        const GREEN: f64 = 0.;
-        const BLUE: f64 = 138.17 / 360.;
-        const ONE_THIRD: f64 = 1. / 3.;
-        const TWO_THIRD: f64 = 2. / 3.;
-        const CYAN_SHIFT: f64 = (BLUE - GREEN) / ONE_THIRD;
-        const MAGENTA_SHIFT: f64 = (RED - BLUE) / ONE_THIRD;
-        const YELLOW_SHIFT: f64 = (1. - RED) / ONE_THIRD;
-
-        let hue = self.hue.val();
-
-        // Shift hue ranges.
-        let rescaled_hue = if hue < ONE_THIRD {
-            hue * CYAN_SHIFT
-        } else if hue < TWO_THIRD {
-            ((hue - ONE_THIRD) * MAGENTA_SHIFT) + BLUE
+        let scaled = self.hue.val() * N_SEG as f64;
+        let seg = (scaled as usize).min(N_SEG - 1);
+        let t = scaled - seg as f64;
+        let p0 = ANCHOR_DEG[seg];
+        let m0 = ANCHOR_TAN[seg];
+        let (p1, m1) = if seg + 1 == N_SEG {
+            // Wraparound: anchor 0 of the next period sits at f[0] + 360°
+            // with the same tangent (function is periodic).
+            (ANCHOR_DEG[0] + 360.0, ANCHOR_TAN[0])
         } else {
-            ((hue - TWO_THIRD) * YELLOW_SHIFT) + RED
+            (ANCHOR_DEG[seg + 1], ANCHOR_TAN[seg + 1])
         };
-        // Convert to degrees and shift up by 127.7 to place green at 0.
-        let hue_degrees = rescaled_hue * 360. + 127.7;
+        let t2 = t * t;
+        let t3 = t2 * t;
+        let hue_degrees = (2.0 * t3 - 3.0 * t2 + 1.0) * p0
+            + (t3 - 2.0 * t2 + t) * m0
+            + (-2.0 * t3 + 3.0 * t2) * p1
+            + (t3 - t2) * m1;
         let (r, g, b) = hsluv_to_rgb(
             hue_degrees,
             self.sat.val() * 100.,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,30 @@
+//! Cobra Commander internals exposed for `examples/` binaries.
+//!
+//! The production entry point is `src/main.rs`; this library surface exists
+//! only so that throwaway example binaries can construct and exercise the
+//! color-conversion code without duplicating it.
+//!
+//! `src/color.rs` derives `AsPatchOption` from `fixture_macros`, which
+//! expands to a reference to `crate::fixture::patch::{AsPatchOption,
+//! PatchOption, enum_patch_option}`. To keep the lib build self-contained,
+//! we provide no-op stubs at those paths. The binary continues to use the
+//! real implementations under `src/fixture/patch/`.
+
+pub mod fixture {
+    pub mod patch {
+        use std::fmt::Display;
+        use strum::IntoEnumIterator;
+
+        pub struct PatchOption;
+
+        pub trait AsPatchOption {
+            fn as_patch_option() -> PatchOption;
+        }
+
+        pub fn enum_patch_option<T: IntoEnumIterator + Display>() -> PatchOption {
+            PatchOption
+        }
+    }
+}
+
+pub mod color;


### PR DESCRIPTION
Update the HSLuv to RGB algorithm to significantly improve the artistic quality of the color space. Implements an inverse hue shift so that the hue coordinate in HSLuv matches the HSV/HSI hue coordinate. This gives much more even representation to the "expected" hues, rather than HSLuv's perceptual bias towards shades of green. This is a significant improvement on the existing "pull the primaries to be 120 degrees apart" hack.

Implement rendering HSLuv colors to RGBW, assuming that the W diode is about twice the brightness as the others. LLM research indicates that this is probably the right choice for most entertainment fixtures, for RGBW and RGBWAU.

Adds a little example binary that renders a PNG showing the output of all three control color spaces into both RGB and an approximation of what RGBW would look like, as well as indications of what each diode is doing.
